### PR TITLE
Rework of collection of variable metadata

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 max-args = 10
-max-attributes=10
+max-attributes=12
 disable=no-else-return
 
 [BASIC]

--- a/doc/user_guide.ipynb
+++ b/doc/user_guide.ipynb
@@ -500,7 +500,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import List\n",
+    "from __future__ import annotations\n",
     "from rkopenmdao.functional_coefficients import FunctionalCoefficients\n",
     "\n",
     "class MultidisciplinaryFunctionalCoefficients(FunctionalCoefficients):\n",
@@ -508,7 +508,7 @@
     "        self.num_steps = num_steps\n",
     "        self.delta_t = delta_t\n",
     "\n",
-    "    def list_quantities(self) -> List[str]:\n",
+    "    def list_quantities(self) -> list[str]:\n",
     "        return [\"x\", \"y\"]\n",
     "    \n",
     "    def get_coefficient(self, time_step: int, quantity: str) -> float:\n",
@@ -603,7 +603,7 @@
    "outputs": [],
    "source": [
     "class NinetyNinthStepFunctionalCoefficients(FunctionalCoefficients):\n",
-    "    def list_quantities(self) -> List[str]:\n",
+    "    def list_quantities(self) -> list[str]:\n",
     "        return [\"log_x\"]\n",
     "    \n",
     "    def get_coefficient(self, time_step: int, quantity: str) -> float:\n",
@@ -904,7 +904,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/doc/user_guide.ipynb
+++ b/doc/user_guide.ipynb
@@ -883,8 +883,8 @@
     "For parallel groups:\n",
     "- Make sure that the in- and output variables really share the same ranks.\n",
     "That can e.g. achieved by manually creating IndependentVariableComponents for the inputs, and grouping them together with the respective component before adding them into a parallel group.\n",
-    "- The variables in the parallel group will only be available on certain ranks, not all of them.\n",
-    "Make sure that this is both reflected in the inputs for a postprocessing problem, and be aware that this will also be the case for the resulting in- and outputs of the time integration component.\n"
+    "- While quantities will only reside on certain ranks in the inner problem, there will be in/outputs on every rank in the`RungeKuttaIntegrator`.\n",
+    "But the size of the variables on all ranks but the ones where the quantity is found in the inner problem will be zero.\n"
    ]
   }
  ],

--- a/examples/heatequation/boundary.py
+++ b/examples/heatequation/boundary.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-module-docstring
-from typing import Callable
+from collections.abc import Callable
 import numpy as np
 
 

--- a/examples/heatequation/heatequation.py
+++ b/examples/heatequation/heatequation.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-module-docstring
-from typing import Union
-from typing import Callable
+from __future__ import annotations
+from collections.abc import Callable
 import numpy as np
 from scipy.sparse.linalg import LinearOperator, gmres
 import h5py

--- a/examples/heatequation/heatequation.py
+++ b/examples/heatequation/heatequation.py
@@ -22,7 +22,7 @@ class HeatEquation:
         heat_inhomogeneity_function: Callable[[float, float, float], float],
         heat_boundary_condition: boundary.BoundaryCondition,
         heat_diffusivity: float,
-        initial_value: Union[np.ndarray, Callable[[float, float], float]],
+        initial_value: np.ndarray | Callable[[float, float], float],
         solver_options: dict,
         start_time=0.0,
     ):

--- a/examples/heatequation/inhomogeneity.py
+++ b/examples/heatequation/inhomogeneity.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-module-docstring
-from typing import Callable
+from collections.abc import Callable
 import numpy as np
 
 from .domain import Domain

--- a/examples/heatequation/split_heat_group.py
+++ b/examples/heatequation/split_heat_group.py
@@ -1,7 +1,7 @@
 """Creation routine for an OpenMDAO problem that models a heat equation split along the
 middle of its domain."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import openmdao.api as om

--- a/examples/heatequation/tests/heat_equation_stage_component_test.py
+++ b/examples/heatequation/tests/heat_equation_stage_component_test.py
@@ -77,7 +77,7 @@ def test_heat_equation_stage_component_zero_vector(
         boundary_condition,
         1.0,
         lambda x, y: 1,
-        {"tol": 1e-10, "atol": "legacy"},
+        {"rtol": 1e-10, "atol": 1e-15},
     )
 
     integration_control = IntegrationControl(0.0, 1, delta_t)
@@ -160,7 +160,7 @@ def test_heat_equation_stage_component_zero_vector_with_one_boundary(
         boundary_condition,
         1.0,
         lambda x, y: 1,
-        {"tol": 1e-10, "atol": "legacy"},
+        {"rtol": 1e-10, "atol": 1e-15},
     )
 
     integration_control = IntegrationControl(0.0, 1, 1, delta_t)
@@ -221,7 +221,7 @@ def test_heat_equation_stage_component_zero_vector_with_all_boundary(
         boundary_condition,
         1.0,
         lambda x, y: 1,
-        {"tol": 1e-10, "atol": "legacy"},
+        {"rtol": 1e-10, "atol": 1e-15},
     )
 
     integration_control = IntegrationControl(0.0, 1, 1, delta_t)
@@ -302,7 +302,7 @@ def test_heat_equation_stage_component_partials(
         boundary_condition,
         1.0,
         lambda x, y: 1,
-        {"tol": 1e-10, "atol": "legacy"},
+        {"rtol": 1e-10, "atol": 1e-15},
     )
 
     integration_control = IntegrationControl(0.0, 1, 1, delta_t)
@@ -379,7 +379,7 @@ def test_heat_equation_stage_component_partials_with_one_boundary(
         boundary_condition,
         1.0,
         lambda x, y: 1,
-        {"tol": 1e-10, "atol": "legacy"},
+        {"rtol": 1e-10, "atol": 1e-15},
     )
 
     integration_control = IntegrationControl(0.0, 1, 1, delta_t)

--- a/examples/heatequation/tests/split_heat_group_test.py
+++ b/examples/heatequation/tests/split_heat_group_test.py
@@ -1,6 +1,6 @@
 """Tests the creator function for the split heat group."""
 
-from typing import Callable
+from collections.abc import Callable
 import pytest
 
 import openmdao.api as om
@@ -27,8 +27,8 @@ integration_control_1 = IntegrationControl(0.0, 1, 1e-4)
 
 
 gmres_args_without_precon = {
-    "tol": 1e-15,
-    "atol": "legacy",
+    "rtol": 1e-10,
+    "atol": 1e-15,
 }
 
 

--- a/examples/simple_parallel_group.py
+++ b/examples/simple_parallel_group.py
@@ -139,17 +139,16 @@ if __name__ == "__main__":
     prob.model.linear_solver = om.PETScKrylov()
     # prob.setup()
     outer_prob = om.Problem()
+    rk_indep = om.IndepVarComp()
+    rk_indep.add_output("x_initial", shape_by_conn=True, distributed=True)
+    rk_indep.add_output("y_initial", shape_by_conn=True, distributed=True)
     rk_integrator = RungeKuttaIntegrator(
         time_stage_problem=prob,
         integration_control=integration_control,
         butcher_tableau=butcher_tableau,
-        time_integration_quantities=(
-            ["x", "y"]
-            if prob.comm.size == 1
-            else ["x"] if prob.comm.rank == 0 else ["y"]
-        ),
+        time_integration_quantities=(["x", "y"]),
     )
-
+    outer_prob.model.add_subsystem("rk_indep", rk_indep, promotes=["*"])
     outer_prob.model.add_subsystem(
         "rk_integrator",
         rk_integrator,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 from setuptools import setup, find_packages
 
-from pathlib import Path
 
 this_dir = Path(__file__).parent
 long_description = (this_dir / "README.md").read_text()

--- a/src/rkopenmdao/checkpoint_interface/checkpoint_interface.py
+++ b/src/rkopenmdao/checkpoint_interface/checkpoint_interface.py
@@ -1,4 +1,6 @@
 # pylint: disable=missing-module-docstring
+
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from collections.abc import Callable

--- a/src/rkopenmdao/checkpoint_interface/checkpoint_interface.py
+++ b/src/rkopenmdao/checkpoint_interface/checkpoint_interface.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-module-docstring
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 

--- a/src/rkopenmdao/checkpoint_interface/runge_kutta_integrator_pyrevolve_classes.py
+++ b/src/rkopenmdao/checkpoint_interface/runge_kutta_integrator_pyrevolve_classes.py
@@ -1,6 +1,7 @@
 """Classes for the usage of the modernized interface of pyrevolve in the
 RungeKuttaIntegrator."""
 
+from __future__ import annotations
 from collections.abc import Mapping, Callable
 
 import pyrevolve as pr

--- a/src/rkopenmdao/checkpoint_interface/runge_kutta_integrator_pyrevolve_classes.py
+++ b/src/rkopenmdao/checkpoint_interface/runge_kutta_integrator_pyrevolve_classes.py
@@ -1,8 +1,7 @@
 """Classes for the usage of the modernized interface of pyrevolve in the
 RungeKuttaIntegrator."""
 
-from collections.abc import Mapping
-from typing import Callable
+from collections.abc import Mapping, Callable
 
 import pyrevolve as pr
 import numpy as np

--- a/src/rkopenmdao/errors.py
+++ b/src/rkopenmdao/errors.py
@@ -7,7 +7,7 @@ class RungeKuttaError(Exception):
 
 class SetupError(RungeKuttaError, ValueError):
     """Exception for the case when something goes wrong in the setup of the
-    RUngeKuttaIntegrator"""
+    RungeKuttaIntegrator"""
 
 
 class PostprocessingError(RungeKuttaError, AssertionError):

--- a/src/rkopenmdao/functional_coefficients.py
+++ b/src/rkopenmdao/functional_coefficients.py
@@ -1,8 +1,7 @@
 """Base class and default for the object to describe linear combinations to the
 RungeKuttaIntegrator."""
 
-from typing import List, Union
-
+from __future__ import annotations
 import numpy as np
 
 from .integration_control import IntegrationControl
@@ -11,15 +10,13 @@ from .integration_control import IntegrationControl
 class FunctionalCoefficients:
     """Base class for the functional coefficients object."""
 
-    def list_quantities(self) -> List[str]:
+    def list_quantities(self) -> list[str]:
         """Returns the list of quantities this objects operates on."""
         raise NotImplementedError(
             "Method 'list_quantities' must be implemented in child class by user."
         )
 
-    def get_coefficient(
-        self, time_step: int, quantity: str
-    ) -> Union[float, np.ndarray]:
+    def get_coefficient(self, time_step: int, quantity: str) -> float | np.ndarray:
         """Given a quantity and a time step, returns the fitting coefficient for the
         linear combination."""
         raise NotImplementedError(
@@ -33,12 +30,10 @@ class EmptyFunctionalCoefficients(FunctionalCoefficients):
     all times and quantities.
     """
 
-    def list_quantities(self) -> List[str]:
+    def list_quantities(self) -> list[str]:
         return []
 
-    def get_coefficient(
-        self, time_step: int, quantity: str
-    ) -> Union[float, np.ndarray]:
+    def get_coefficient(self, time_step: int, quantity: str) -> float | np.ndarray:
         return 0.0
 
 

--- a/src/rkopenmdao/functional_coefficients.py
+++ b/src/rkopenmdao/functional_coefficients.py
@@ -43,17 +43,15 @@ class AverageCoefficients(FunctionalCoefficients):
     """
 
     def __init__(
-        self, integration_control: IntegrationControl, quantity_list: List[str]
+        self, integration_control: IntegrationControl, quantity_list: list[str]
     ):
-        self._quantity_list: List[str] = quantity_list
+        self._quantity_list: list[str] = quantity_list
         self._integration_control: IntegrationControl = integration_control
 
-    def list_quantities(self) -> List[str]:
+    def list_quantities(self) -> list[str]:
         return self._quantity_list
 
-    def get_coefficient(
-        self, time_step: int, quantity: str
-    ) -> Union[float, np.ndarray]:
+    def get_coefficient(self, time_step: int, quantity: str) -> float | np.ndarray:
         return (self._integration_control.num_steps + 1) ** -1
 
 
@@ -64,17 +62,15 @@ class CompositeTrapezoidalCoefficients(FunctionalCoefficients):
     """
 
     def __init__(
-        self, integration_control: IntegrationControl, quantity_list: List[str]
+        self, integration_control: IntegrationControl, quantity_list: list[str]
     ):
-        self._quantity_list: List[str] = quantity_list
+        self._quantity_list: list[str] = quantity_list
         self._integration_control: IntegrationControl = integration_control
 
-    def list_quantities(self) -> List[str]:
+    def list_quantities(self) -> list[str]:
         return self._quantity_list
 
-    def get_coefficient(
-        self, time_step: int, quantity: str
-    ) -> Union[float, np.ndarray]:
+    def get_coefficient(self, time_step: int, quantity: str) -> float | np.ndarray:
         if time_step in (0, self._integration_control.num_steps):
             return 0.5 * self._integration_control.delta_t
         else:

--- a/src/rkopenmdao/metadata_extractor.py
+++ b/src/rkopenmdao/metadata_extractor.py
@@ -1,3 +1,8 @@
+"""Methods for extracting metadata from the inner OpenMDAO problems of the
+RungeKuttaIntegrator used for organizing its own data structures."""
+
+# pylint: disable=protected-access
+
 import numpy as np
 import openmdao.api as om
 
@@ -6,7 +11,10 @@ from mpi4py import MPI
 
 def extract_time_integration_metadata(
     stage_problem: om.Problem, time_integration_quantity_list: list
-):
+) -> tuple[int, dict, dict]:
+    """Extracts metadata from the time stage problem and returns the size of the
+    integrators internal array, a dict to translate to the inner problem, and a dict
+    containing variable information."""
     local_quantities = stage_problem.model.get_io_metadata(
         iotypes="output",
         metadata_keys=["tags"],
@@ -52,93 +60,21 @@ def extract_time_integration_metadata(
         if var in local_quantities:
             tags = time_integration_set & set(data["tags"])
             assert len(tags) == 1, (
-                f"Variable {var} either has two time integration quantity tags, or 'stage_output_var' was "
-                f"used as quantity tag. Both are forbidden. Tags of {var} intersected with time integration "
-                f"quantities: {tags}."
+                f"Variable {var} either has two time integration quantity tags, "
+                "or 'stage_output_var' was used as quantity tag. Both are forbidden. "
+                f"Tags of {var} intersected with time integration quantities: {tags}."
             )
 
             quantity = tags.pop()
             quantity_metadata[quantity]["local"] = True
-            detailed_local_quantity = stage_problem.model.get_io_metadata(
-                metadata_keys=["tags", "shape", "global_shape"],
-                tags=[quantity],
-                get_remote=False,
-            )
-            found_stage_output_var = 0
-            found_step_input_var = 0
-            found_accumulated_stage_var = 0
-            for detailed_var, detailed_data in detailed_local_quantity.items():
-                if "stage_output_var" in detailed_data["tags"]:
-                    found_stage_output_var += 1
-                    translation_metadata[quantity]["stage_output_var"] = detailed_var
-                    quantity_metadata[quantity]["shape"] = detailed_data["shape"]
-                    quantity_metadata[quantity]["global_shape"] = detailed_data[
-                        "global_shape"
-                    ]
-                    quantity_metadata[quantity]["start_index"] = array_size
-                    array_size += np.prod(detailed_data["shape"])
-                    quantity_metadata[quantity]["end_index"] = array_size
-                    if detailed_data["shape"] != detailed_data["global_shape"]:
-                        try:
-                            sizes = stage_problem.model._var_sizes["output"][
-                                :,
-                                stage_problem.model._var_allprocs_abs2idx[detailed_var],
-                            ]
-                        except KeyError:  # Have to deal with an older openMDAO version
-                            sizes = stage_problem.model._var_sizes["nonlinear"][
-                                "output"
-                            ][
-                                :,
-                                stage_problem.model._var_allprocs_abs2idx["nonlinear"][
-                                    detailed_var
-                                ],
-                            ]
-                        quantity_metadata[quantity]["global_start_index"] = start = (
-                            np.sum(sizes[: stage_problem.comm.rank])
-                        )
-                        quantity_metadata[quantity]["global_end_index"] = (
-                            start + sizes[stage_problem.comm.rank]
-                        )
-                    else:
-                        quantity_metadata[quantity]["global_start_index"] = 0
-                        quantity_metadata[quantity]["global_end_index"] = np.prod(
-                            detailed_data["shape"]
-                        )
-                elif "step_input_var" in detailed_data["tags"]:
-                    found_step_input_var += 1
-                    translation_metadata[quantity]["step_input_var"] = detailed_var
-                elif "accumulated_stage_var" in detailed_data["tags"]:
-                    found_accumulated_stage_var += 1
-                    translation_metadata[quantity][
-                        "accumulated_stage_var"
-                    ] = detailed_var
-            assert (
-                found_stage_output_var <= 1
-            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'stage_output_var'."
-
-            assert (
-                found_step_input_var <= 1
-            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'step_input_var'."
-
-            assert (
-                found_accumulated_stage_var <= 1
-            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'accumulated_stage_var'."
-
-            assert (
-                found_stage_output_var >= 1
-            ), f"For quantity {quantity}, there is no inner variable tagged with 'stage_output_var'."
-
-            assert (found_step_input_var, found_accumulated_stage_var) in [
-                (0, 0),
-                (1, 1),
-            ], (
-                f"For quantity {quantity}, there is either a variable tagged for 'step_input_var, but not "
-                "'accumulated_stage_var', or vice versa. Either none or both have to be present."
-            )
-            print(
-                found_step_input_var,
-                found_accumulated_stage_var,
-                found_stage_output_var,
+            array_size, translation_metadata, quantity_metadata = (
+                _extract_detailed_time_integration_info(
+                    quantity,
+                    stage_problem,
+                    array_size,
+                    translation_metadata,
+                    quantity_metadata,
+                )
             )
 
     return (
@@ -148,13 +84,101 @@ def extract_time_integration_metadata(
     )
 
 
+def _extract_detailed_time_integration_info(
+    quantity: str,
+    stage_problem: om.Problem,
+    array_size: int,
+    translation_metadata: dict,
+    quantity_metadata: dict,
+) -> tuple[int, dict, dict]:
+    detailed_local_quantity = stage_problem.model.get_io_metadata(
+        metadata_keys=["tags", "shape", "global_shape"],
+        tags=[quantity],
+        get_remote=False,
+    )
+    found_stage_output_var = 0
+    found_step_input_var = 0
+    found_accumulated_stage_var = 0
+    for detailed_var, detailed_data in detailed_local_quantity.items():
+        if "stage_output_var" in detailed_data["tags"]:
+            found_stage_output_var += 1
+            translation_metadata[quantity]["stage_output_var"] = detailed_var
+            quantity_metadata[quantity]["shape"] = detailed_data["shape"]
+            quantity_metadata[quantity]["global_shape"] = detailed_data["global_shape"]
+            quantity_metadata[quantity]["start_index"] = array_size
+            array_size += np.prod(detailed_data["shape"])
+            quantity_metadata[quantity]["end_index"] = array_size
+            if detailed_data["shape"] != detailed_data["global_shape"]:
+                try:
+                    sizes = stage_problem.model._var_sizes["output"][
+                        :,
+                        stage_problem.model._var_allprocs_abs2idx[detailed_var],
+                    ]
+                except KeyError:  # Have to deal with an older openMDAO version
+                    sizes = stage_problem.model._var_sizes["nonlinear"]["output"][
+                        :,
+                        stage_problem.model._var_allprocs_abs2idx["nonlinear"][
+                            detailed_var
+                        ],
+                    ]
+                quantity_metadata[quantity]["global_start_index"] = start = np.sum(
+                    sizes[: stage_problem.comm.rank]
+                )
+                quantity_metadata[quantity]["global_end_index"] = (
+                    start + sizes[stage_problem.comm.rank]
+                )
+            else:
+                quantity_metadata[quantity]["global_start_index"] = 0
+                quantity_metadata[quantity]["global_end_index"] = np.prod(
+                    detailed_data["shape"]
+                )
+        elif "step_input_var" in detailed_data["tags"]:
+            found_step_input_var += 1
+            translation_metadata[quantity]["step_input_var"] = detailed_var
+        elif "accumulated_stage_var" in detailed_data["tags"]:
+            found_accumulated_stage_var += 1
+            translation_metadata[quantity]["accumulated_stage_var"] = detailed_var
+    assert found_stage_output_var <= 1, (
+        f"For quantity {quantity}, there is more than one inner variable tagged"
+        f" with 'stage_output_var'."
+    )
+
+    assert found_step_input_var <= 1, (
+        f"For quantity {quantity}, there is more than one inner variable tagged"
+        f" with 'step_input_var'."
+    )
+
+    assert found_accumulated_stage_var <= 1, (
+        f"For quantity {quantity}, there is more than one inner variable tagged"
+        f" with 'accumulated_stage_var'."
+    )
+
+    assert found_stage_output_var >= 1, (
+        f"For quantity {quantity}, there is no inner variable tagged with "
+        f"'stage_output_var'."
+    )
+
+    assert (found_step_input_var, found_accumulated_stage_var) in [
+        (0, 0),
+        (1, 1),
+    ], (
+        f"For quantity {quantity}, there is either a variable tagged for"
+        f" 'step_input_var, but not 'accumulated_stage_var', or vice versa. "
+        f"Either none or both have to be present."
+    )
+    return array_size, translation_metadata, quantity_metadata
+
+
 def add_postprocessing_metadata(
     postproc_problem: om.Problem,
     time_integration_quantity_list: list,
     postprocessing_quantity_list: list,
     quantity_metadata: dict,
     translation_metadata: dict,
-):
+) -> tuple[int, dict, dict]:
+    """Extracts metadata from the postprocessing problem and adds it to the passed
+    metadata dicts. Returns them, as well as the size for the internal postprocessing
+    state array."""
     postproc_input_vars = postproc_problem.model.get_io_metadata(
         iotypes="input",
         metadata_keys=["tags"],
@@ -198,26 +222,16 @@ def add_postprocessing_metadata(
     for var, data in postproc_input_vars.items():
         tags = data["tags"] & time_integration_set
         assert len(tags) == 1, (
-            f"Variable {var} either has two time integration quantity tags, or 'postproc_input_var' was "
-            f"used as quantity tag. Both are forbidden. Tags of {var} intersected with time integration "
-            f"quantities: {tags}."
+            f"Variable {var} either has two time integration quantity tags, or "
+            f"'postproc_input_var' was used as quantity tag. Both are forbidden. Tags "
+            f"of {var} intersected with time integration quantities: {tags}."
         )
 
         quantity = tags.pop()
-        detailed_local_quantity = postproc_problem.model.get_io_metadata(
-            metadata_keys=["tags"],
-            tags=[quantity],
-            get_remote=False,
+
+        translation_metadata = _extract_detailed_postprocessing_input_info(
+            quantity, postproc_problem, translation_metadata
         )
-        found_postproc_input_var = 0
-        # At least one variable will be found in here, so found_postproc_input_var will be greater than zero
-        for detailed_var, detailed_data in detailed_local_quantity.items():
-            if "postproc_input_var" in detailed_data["tags"]:
-                found_postproc_input_var += 1
-                translation_metadata[quantity]["postproc_input_var"] = detailed_var
-        assert (
-            found_postproc_input_var == 1
-        ), f"More than one variable with quantity tag {quantity} for 'postproc_input_var' in postprocessing_problem."
 
     local_postproc_quantities = postproc_problem.model.get_io_metadata(
         iotypes="output",
@@ -237,65 +251,23 @@ def add_postprocessing_metadata(
         if var in local_postproc_quantities:
             tags = postprocessing_set & set(data["tags"])
             assert len(tags) == 1, (
-                f"Variable {var} either has two postprocessing quantity tags, or 'postproc_output_var' was "
-                f"used as quantity tag. Both are forbidden. Tags of {var} intersected with time integration "
-                f"quantities: {tags}."
+                f"Variable {var} either has two postprocessing quantity tags, or "
+                f"'postproc_output_var' was used as quantity tag. Both are forbidden. "
+                f"Tags of {var} intersected with time integration quantities: {tags}."
             )
 
             quantity = tags.pop()
             quantity_metadata[quantity]["local"] = True
-            detailed_local_quantity = postproc_problem.model.get_io_metadata(
-                metadata_keys=["tags", "shape", "global_shape"],
-                tags=[quantity],
-                get_remote=False,
-            )
-            found_postproc_output_var = 0
-            for detailed_var, detailed_data in detailed_local_quantity.items():
-                if "postproc_output_var" in detailed_data["tags"]:
-                    found_postproc_output_var += 1
-                    translation_metadata[quantity]["postproc_output_var"] = detailed_var
-                    quantity_metadata[quantity]["shape"] = detailed_data["shape"]
-                    quantity_metadata[quantity]["global_shape"] = detailed_data[
-                        "global_shape"
-                    ]
-                    quantity_metadata[quantity]["start_index"] = array_size
-                    array_size += np.prod(detailed_data["shape"])
-                    quantity_metadata[quantity]["end_index"] = array_size
-                    if detailed_data["shape"] != detailed_data["global_shape"]:
-                        try:
-                            sizes = postproc_problem.model._var_sizes["output"][
-                                :,
-                                postproc_problem.model._var_allprocs_abs2idx[
-                                    detailed_var
-                                ],
-                            ]
-                        except KeyError:  # Have to deal with an older openMDAO version
-                            sizes = postproc_problem.model._var_sizes["nonlinear"][
-                                "output"
-                            ][
-                                :,
-                                postproc_problem.model._var_allprocs_abs2idx[
-                                    "nonlinear"
-                                ][detailed_var],
-                            ]
-                        quantity_metadata[quantity]["global_start_index"] = start = (
-                            np.sum(sizes[: postproc_problem.comm.rank])
-                        )
-                        quantity_metadata[quantity]["global_end_index"] = (
-                            start + sizes[postproc_problem.comm.rank]
-                        )
-                    else:
-                        quantity_metadata[quantity]["global_start_index"] = 0
-                        quantity_metadata[quantity]["global_end_index"] = np.prod(
-                            detailed_data["shape"]
-                        )
-            assert (
-                found_postproc_output_var <= 1
-            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'postproc_output_var'."
 
-            assert (
-                found_postproc_output_var >= 1
-            ), f"For quantity {quantity}, there is no inner variable tagged with 'postproc_output_vars'."
+            array_size, translation_metadata, quantity_metadata = (
+                _extract_detailed_postprocessing_output_info(
+                    quantity,
+                    postproc_problem,
+                    array_size,
+                    translation_metadata,
+                    quantity_metadata,
+                )
+            )
 
     return (
         array_size,
@@ -304,10 +276,95 @@ def add_postprocessing_metadata(
     )
 
 
-def add_functional_metadata(functional_quantities: list, quantity_metadata: dict):
-    assert set(functional_quantities).issubset(
-        set(quantity_metadata.keys())
-    ), "Some functional requires a quantity that is part of neither the time integration nor postprocessing."
+def _extract_detailed_postprocessing_input_info(
+    quantity: str, postproc_problem: om.Problem, translation_metadata
+) -> dict:
+    detailed_local_quantity = postproc_problem.model.get_io_metadata(
+        metadata_keys=["tags"],
+        tags=[quantity],
+        get_remote=False,
+    )
+    found_postproc_input_var = 0
+    # At least one variable will be found in here, so found_postproc_input_var will
+    # be greater than zero
+    for detailed_var, detailed_data in detailed_local_quantity.items():
+        if "postproc_input_var" in detailed_data["tags"]:
+            found_postproc_input_var += 1
+            translation_metadata[quantity]["postproc_input_var"] = detailed_var
+    assert found_postproc_input_var == 1, (
+        f"More than one variable with quantity tag {quantity} for "
+        f"'postproc_input_var' in postprocessing_problem."
+    )
+    return translation_metadata
+
+
+def _extract_detailed_postprocessing_output_info(
+    quantity: str,
+    postproc_problem: om.Problem,
+    array_size: int,
+    translation_metadata: dict,
+    quantity_metadata: dict,
+) -> tuple[int, dict, dict]:
+    detailed_local_quantity = postproc_problem.model.get_io_metadata(
+        metadata_keys=["tags", "shape", "global_shape"],
+        tags=[quantity],
+        get_remote=False,
+    )
+    found_postproc_output_var = 0
+    for detailed_var, detailed_data in detailed_local_quantity.items():
+        if "postproc_output_var" in detailed_data["tags"]:
+            found_postproc_output_var += 1
+            translation_metadata[quantity]["postproc_output_var"] = detailed_var
+            quantity_metadata[quantity]["shape"] = detailed_data["shape"]
+            quantity_metadata[quantity]["global_shape"] = detailed_data["global_shape"]
+            quantity_metadata[quantity]["start_index"] = array_size
+            array_size += np.prod(detailed_data["shape"])
+            quantity_metadata[quantity]["end_index"] = array_size
+            if detailed_data["shape"] != detailed_data["global_shape"]:
+                try:
+                    sizes = postproc_problem.model._var_sizes["output"][
+                        :,
+                        postproc_problem.model._var_allprocs_abs2idx[detailed_var],
+                    ]
+                except KeyError:  # Have to deal with an older openMDAO version
+                    sizes = postproc_problem.model._var_sizes["nonlinear"]["output"][
+                        :,
+                        postproc_problem.model._var_allprocs_abs2idx["nonlinear"][
+                            detailed_var
+                        ],
+                    ]
+                quantity_metadata[quantity]["global_start_index"] = start = np.sum(
+                    sizes[: postproc_problem.comm.rank]
+                )
+                quantity_metadata[quantity]["global_end_index"] = (
+                    start + sizes[postproc_problem.comm.rank]
+                )
+            else:
+                quantity_metadata[quantity]["global_start_index"] = 0
+                quantity_metadata[quantity]["global_end_index"] = np.prod(
+                    detailed_data["shape"]
+                )
+    assert found_postproc_output_var <= 1, (
+        f"For quantity {quantity}, there is more than one inner variable tagged"
+        f" with 'postproc_output_var'."
+    )
+
+    assert found_postproc_output_var >= 1, (
+        f"For quantity {quantity}, there is no inner variable tagged with "
+        f"'postproc_output_vars'."
+    )
+    return array_size, translation_metadata, quantity_metadata
+
+
+def add_functional_metadata(
+    functional_quantities: list, quantity_metadata: dict
+) -> tuple[int, dict]:
+    """Adds metadata in the quantity metadata dict based on which functionals are part
+    of a functional. Also returns the size of the internal functional state array."""
+    assert set(functional_quantities).issubset(set(quantity_metadata.keys())), (
+        "Some functional requires a quantity that is part of neither the time "
+        "integration nor postprocessing."
+    )
 
     array_size = 0
     for quantity in functional_quantities:
@@ -319,10 +376,15 @@ def add_functional_metadata(functional_quantities: list, quantity_metadata: dict
     return array_size, quantity_metadata
 
 
-def add_distributivity_information(stage_problem: om.Problem, quantity_metadata: dict):
-    for quantity, metadata in quantity_metadata.items():
+def add_distributivity_information(
+    stage_problem: om.Problem, quantity_metadata: dict
+) -> None:
+    """Adds information about the distributed structure of data the the quantity
+    metadata dict."""
+    for metadata in quantity_metadata.values():
         local = np.array([metadata["local"]])
         everywhere_local = np.zeros_like(local)
+        # pylint: disable=c-extension-no-member
         stage_problem.comm.Allreduce(local, everywhere_local, MPI.LAND)
         if everywhere_local:
             metadata["distributed"] = metadata["shape"] != metadata["global_shape"]
@@ -330,8 +392,8 @@ def add_distributivity_information(stage_problem: om.Problem, quantity_metadata:
             metadata["distributed"] = True
 
 
-# TODO: we will later want to differentiate the algebraic part of DAEs (to take advantage of the FSAL property
-#  of some butcher tableaux/RK schemes)
+# TODO: we will later want to differentiate the algebraic part of DAEs (to take
+#  advantage of the FSAL property of some butcher tableaux/RK schemes)
 # def add_algebraic_metadata(
 #     stage_problem: om.Problem,
 #     time_integration_quantity_list: list,
@@ -340,7 +402,8 @@ def add_distributivity_information(stage_problem: om.Problem, quantity_metadata:
 # ):
 #     pass
 
-# TODO: we will later want the ability to passthrough parameters to the outside problem for optimization
+# TODO: we will later want the ability to passthrough parameters to the outside problem
+#  for optimization
 # def add_passthrough_metadata(
 #     stage_problem: om.Problem,
 #     time_integration_quantity_list: list,

--- a/src/rkopenmdao/metadata_extractor.py
+++ b/src/rkopenmdao/metadata_extractor.py
@@ -1,0 +1,353 @@
+import numpy as np
+import openmdao.api as om
+
+from mpi4py import MPI
+
+
+def extract_time_integration_metadata(
+    stage_problem: om.Problem, time_integration_quantity_list: list
+):
+    local_quantities = stage_problem.model.get_io_metadata(
+        iotypes="output",
+        metadata_keys=["tags"],
+        tags=time_integration_quantity_list,
+        get_remote=False,
+    )
+    global_quantities = stage_problem.model.get_io_metadata(
+        iotypes="output",
+        metadata_keys=["tags"],
+        tags=time_integration_quantity_list,
+        get_remote=True,
+    )
+    translation_metadata = {
+        quantity: {
+            "step_input_var": None,
+            "accumulated_stage_var": None,
+            "stage_output_var": None,
+            "postproc_input_var": None,
+        }
+        for quantity in time_integration_quantity_list
+    }
+    quantity_metadata = {
+        quantity: {
+            "type": "time_integration",
+            "shape": 0,
+            "global_shape": 0,
+            "local": False,
+            "distributed": False,
+            "start_index": 0,
+            "end_index": 0,
+            "functionally_integrated": False,
+            "functional_start_index": 0,
+            "functional_end_index": 0,
+            "global_start_index": 0,
+            "global_end_index": 0,
+        }
+        for quantity in time_integration_quantity_list
+    }
+    array_size = 0
+
+    time_integration_set = set(time_integration_quantity_list)
+    for var, data in global_quantities.items():
+        if var in local_quantities:
+            tags = time_integration_set & set(data["tags"])
+            assert len(tags) == 1, (
+                f"Variable {var} either has two time integration quantity tags, or 'stage_output_var' was "
+                f"used as quantity tag. Both are forbidden. Tags of {var} intersected with time integration "
+                f"quantities: {tags}."
+            )
+
+            quantity = tags.pop()
+            quantity_metadata[quantity]["local"] = True
+            detailed_local_quantity = stage_problem.model.get_io_metadata(
+                metadata_keys=["tags", "shape", "global_shape"],
+                tags=[quantity],
+                get_remote=False,
+            )
+            found_stage_output_var = 0
+            found_step_input_var = 0
+            found_accumulated_stage_var = 0
+            for detailed_var, detailed_data in detailed_local_quantity.items():
+                if "stage_output_var" in detailed_data["tags"]:
+                    found_stage_output_var += 1
+                    translation_metadata[quantity]["stage_output_var"] = detailed_var
+                    quantity_metadata[quantity]["shape"] = detailed_data["shape"]
+                    quantity_metadata[quantity]["global_shape"] = detailed_data[
+                        "global_shape"
+                    ]
+                    quantity_metadata[quantity]["start_index"] = array_size
+                    array_size += np.prod(detailed_data["shape"])
+                    quantity_metadata[quantity]["end_index"] = array_size
+                    if detailed_data["shape"] != detailed_data["global_shape"]:
+                        try:
+                            sizes = stage_problem.model._var_sizes["output"][
+                                :,
+                                stage_problem.model._var_allprocs_abs2idx[detailed_var],
+                            ]
+                        except KeyError:  # Have to deal with an older openMDAO version
+                            sizes = stage_problem.model._var_sizes["nonlinear"][
+                                "output"
+                            ][
+                                :,
+                                stage_problem.model._var_allprocs_abs2idx["nonlinear"][
+                                    detailed_var
+                                ],
+                            ]
+                        quantity_metadata[quantity]["global_start_index"] = start = (
+                            np.sum(sizes[: stage_problem.comm.rank])
+                        )
+                        quantity_metadata[quantity]["global_end_index"] = (
+                            start + sizes[stage_problem.comm.rank]
+                        )
+                    else:
+                        quantity_metadata[quantity]["global_start_index"] = 0
+                        quantity_metadata[quantity]["global_end_index"] = np.prod(
+                            detailed_data["shape"]
+                        )
+                elif "step_input_var" in detailed_data["tags"]:
+                    found_step_input_var += 1
+                    translation_metadata[quantity]["step_input_var"] = detailed_var
+                elif "accumulated_stage_var" in detailed_data["tags"]:
+                    found_accumulated_stage_var += 1
+                    translation_metadata[quantity][
+                        "accumulated_stage_var"
+                    ] = detailed_var
+            assert (
+                found_stage_output_var <= 1
+            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'stage_output_var'."
+
+            assert (
+                found_step_input_var <= 1
+            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'step_input_var'."
+
+            assert (
+                found_accumulated_stage_var <= 1
+            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'accumulated_stage_var'."
+
+            assert (
+                found_stage_output_var >= 1
+            ), f"For quantity {quantity}, there is no inner variable tagged with 'stage_output_var'."
+
+            assert (found_step_input_var, found_accumulated_stage_var) in [
+                (0, 0),
+                (1, 1),
+            ], (
+                f"For quantity {quantity}, there is either a variable tagged for 'step_input_var, but not "
+                "'accumulated_stage_var', or vice versa. Either none or both have to be present."
+            )
+
+    assert len(translation_metadata) == len(time_integration_quantity_list) and len(
+        quantity_metadata
+    ) == len(
+        time_integration_quantity_list
+    ), "There are some passed time integration quantity tags that have no tagged variables in the stage problem."
+    return (
+        array_size,
+        translation_metadata,
+        quantity_metadata,
+    )
+
+
+def add_postprocessing_metadata(
+    postproc_problem: om.Problem,
+    time_integration_quantity_list: list,
+    postprocessing_quantity_list: list,
+    quantity_metadata: dict,
+    translation_metadata: dict,
+):
+    postproc_input_vars = postproc_problem.model.get_io_metadata(
+        iotypes="input",
+        metadata_keys=["tags"],
+        tags=["postproc_input_var"],
+        get_remote=False,
+    )
+    time_integration_set = set(time_integration_quantity_list)
+    postprocessing_set = set(postprocessing_quantity_list)
+    assert time_integration_set.isdisjoint(
+        postprocessing_set
+    ), "time integration and postprocessing quantities have to be disjoint"
+
+    translation_metadata.update(
+        {
+            quantity: {
+                "postproc_output_var": None,
+            }
+            for quantity in postprocessing_quantity_list
+        }
+    )
+    quantity_metadata.update(
+        {
+            quantity: {
+                "type": "postprocessing",
+                "shape": 0,
+                "global_shape": 0,
+                "local": False,
+                "start_index": 0,
+                "end_index": 0,
+                "functionally_integrated": False,
+                "functional_start_index": 0,
+                "functional_end_index": 0,
+                "global_start_index": 0,
+                "global_end_index": 0,
+            }
+            for quantity in postprocessing_quantity_list
+        }
+    )
+
+    for var, data in postproc_input_vars.items():
+        tags = data["tags"] & time_integration_set
+        assert len(tags) == 1, (
+            f"Variable {var} either has two time integration quantity tags, or 'postproc_input_var' was "
+            f"used as quantity tag. Both are forbidden. Tags of {var} intersected with time integration "
+            f"quantities: {tags}."
+        )
+
+        quantity = tags.pop()
+        detailed_local_quantity = postproc_problem.model.get_io_metadata(
+            metadata_keys=["tags"],
+            tags=[quantity],
+            get_remote=False,
+        )
+        found_postproc_input_var = 0
+        for detailed_var, detailed_data in detailed_local_quantity.items():
+            if "postproc_input_var" in detailed_data["tags"]:
+                found_postproc_input_var += 1
+                translation_metadata[quantity]["postproc_input_var"] = detailed_var
+        assert (
+            found_postproc_input_var == 1
+        ), f"More than one variable with quantity tag {quantity} for 'postproc_input_var' in postprocessing_problem."
+
+    local_postproc_quantities = postproc_problem.model.get_io_metadata(
+        iotypes="output",
+        metadata_keys=["tags"],
+        tags=postprocessing_quantity_list,
+        get_remote=False,
+    )
+    global_postproc_quantities = postproc_problem.model.get_io_metadata(
+        iotypes="output",
+        metadata_keys=["tags"],
+        tags=postprocessing_quantity_list,
+        get_remote=True,
+    )
+    array_size = 0
+
+    for var, data in global_postproc_quantities.items():
+        if var in local_postproc_quantities:
+            tags = postprocessing_set & set(data["tags"])
+            assert len(tags) == 1, (
+                f"Variable {var} either has two postprocessing quantity tags, or 'postproc_output_var' was "
+                f"used as quantity tag. Both are forbidden. Tags of {var} intersected with time integration "
+                f"quantities: {tags}."
+            )
+
+            quantity = tags.pop()
+            quantity_metadata[quantity]["local"] = True
+            detailed_local_quantity = postproc_problem.model.get_io_metadata(
+                metadata_keys=["tags", "shape", "global_shape"],
+                tags=[quantity],
+                get_remote=False,
+            )
+            found_postproc_output_var = 0
+            for detailed_var, detailed_data in detailed_local_quantity.items():
+                if "postproc_output_var" in detailed_data["tags"]:
+                    found_postproc_output_var += 1
+                    translation_metadata[quantity]["postproc_output_var"] = detailed_var
+                    quantity_metadata[quantity]["shape"] = detailed_data["shape"]
+                    quantity_metadata[quantity]["global_shape"] = detailed_data[
+                        "global_shape"
+                    ]
+                    quantity_metadata[quantity]["start_index"] = array_size
+                    array_size += np.prod(detailed_data["shape"])
+                    quantity_metadata[quantity]["end_index"] = array_size
+                    if detailed_data["shape"] != detailed_data["global_shape"]:
+                        try:
+                            sizes = postproc_problem.model._var_sizes["output"][
+                                :,
+                                postproc_problem.model._var_allprocs_abs2idx[
+                                    detailed_var
+                                ],
+                            ]
+                        except KeyError:  # Have to deal with an older openMDAO version
+                            sizes = postproc_problem.model._var_sizes["nonlinear"][
+                                "output"
+                            ][
+                                :,
+                                postproc_problem.model._var_allprocs_abs2idx[
+                                    "nonlinear"
+                                ][detailed_var],
+                            ]
+                        quantity_metadata[quantity]["global_start_index"] = start = (
+                            np.sum(sizes[: postproc_problem.comm.rank])
+                        )
+                        quantity_metadata[quantity]["global_end_index"] = (
+                            start + sizes[postproc_problem.comm.rank]
+                        )
+                    else:
+                        quantity_metadata[quantity]["global_start_index"] = 0
+                        quantity_metadata[quantity]["global_end_index"] = np.prod(
+                            detailed_data["shape"]
+                        )
+            assert (
+                found_postproc_output_var <= 1
+            ), f"For quantity {quantity}, there is more than one inner variable tagged with 'postproc_output_var'."
+
+            assert (
+                found_postproc_output_var >= 1
+            ), f"For quantity {quantity}, there is no inner variable tagged with 'postproc_output_vars'."
+
+    assert len(translation_metadata) == len(time_integration_quantity_list) + len(
+        postprocessing_quantity_list
+    ) and len(quantity_metadata) == len(time_integration_quantity_list) + len(
+        postprocessing_quantity_list
+    ), "There are some passed postprocessing quantity tags that have no tagged variables in the stage problem."
+    return (
+        array_size,
+        translation_metadata,
+        quantity_metadata,
+    )
+
+
+def add_functional_metadata(functional_quantities: list, quantity_metadata: dict):
+    assert set(functional_quantities).issubset(
+        set(quantity_metadata.keys())
+    ), "Some functional requires a quantity that is part of neither the time integration nor postprocessing."
+
+    array_size = 0
+    for quantity in functional_quantities:
+        quantity_metadata[quantity]["functionally_integrated"] = True
+        if quantity_metadata[quantity]["local"]:
+            quantity_metadata[quantity]["functional_start_index"] = array_size
+            array_size += np.prod(quantity_metadata[quantity]["shape"])
+            quantity_metadata[quantity]["functional_end_index"] = array_size
+    return array_size, quantity_metadata
+
+
+def add_distributivity_information(stage_problem: om.Problem, quantity_metadata: dict):
+    for quantity, metadata in quantity_metadata.items():
+        local = np.array([metadata["local"]])
+        everywhere_local = np.zeros_like(local)
+        stage_problem.comm.Allreduce(local, everywhere_local, MPI.LAND)
+        if everywhere_local:
+            metadata["distributed"] = metadata["shape"] != metadata["global_shape"]
+        else:
+            metadata["distributed"] = True
+
+
+# TODO: we will later want to differentiate the algebraic part of DAEs (to take advantage of the FSAL property
+#  of some butcher tableaux/RK schemes)
+# def add_algebraic_metadata(
+#     stage_problem: om.Problem,
+#     time_integration_quantity_list: list,
+#     quantity_metadata: dict,
+#     translation_metadata: dict,
+# ):
+#     pass
+
+# TODO: we will later want the ability to passthrough parameters to the outside problem for optimization
+# def add_passthrough_metadata(
+#     stage_problem: om.Problem,
+#     time_integration_quantity_list: list,
+#     quantity_metadata: dict,
+#     translation_metadata: dict,
+# ):
+#     pass

--- a/src/rkopenmdao/metadata_extractor.py
+++ b/src/rkopenmdao/metadata_extractor.py
@@ -2,6 +2,7 @@
 RungeKuttaIntegrator used for organizing its own data structures."""
 
 # pylint: disable=protected-access
+from typing import Tuple
 
 import numpy as np
 import openmdao.api as om
@@ -11,7 +12,7 @@ from mpi4py import MPI
 
 def extract_time_integration_metadata(
     stage_problem: om.Problem, time_integration_quantity_list: list
-) -> tuple[int, dict, dict]:
+) -> Tuple[int, dict, dict]:
     """Extracts metadata from the time stage problem and returns the size of the
     integrators internal array, a dict to translate to the inner problem, and a dict
     containing variable information."""
@@ -90,7 +91,7 @@ def _extract_detailed_time_integration_info(
     array_size: int,
     translation_metadata: dict,
     quantity_metadata: dict,
-) -> tuple[int, dict, dict]:
+) -> Tuple[int, dict, dict]:
     detailed_local_quantity = stage_problem.model.get_io_metadata(
         metadata_keys=["tags", "shape", "global_shape"],
         tags=[quantity],
@@ -175,7 +176,7 @@ def add_postprocessing_metadata(
     postprocessing_quantity_list: list,
     quantity_metadata: dict,
     translation_metadata: dict,
-) -> tuple[int, dict, dict]:
+) -> Tuple[int, dict, dict]:
     """Extracts metadata from the postprocessing problem and adds it to the passed
     metadata dicts. Returns them, as well as the size for the internal postprocessing
     state array."""
@@ -304,7 +305,7 @@ def _extract_detailed_postprocessing_output_info(
     array_size: int,
     translation_metadata: dict,
     quantity_metadata: dict,
-) -> tuple[int, dict, dict]:
+) -> Tuple[int, dict, dict]:
     detailed_local_quantity = postproc_problem.model.get_io_metadata(
         metadata_keys=["tags", "shape", "global_shape"],
         tags=[quantity],
@@ -358,7 +359,7 @@ def _extract_detailed_postprocessing_output_info(
 
 def add_functional_metadata(
     functional_quantities: list, quantity_metadata: dict
-) -> tuple[int, dict]:
+) -> Tuple[int, dict]:
     """Adds metadata in the quantity metadata dict based on which functionals are part
     of a functional. Also returns the size of the internal functional state array."""
     assert set(functional_quantities).issubset(set(quantity_metadata.keys())), (

--- a/src/rkopenmdao/metadata_extractor.py
+++ b/src/rkopenmdao/metadata_extractor.py
@@ -135,12 +135,12 @@ def extract_time_integration_metadata(
                 f"For quantity {quantity}, there is either a variable tagged for 'step_input_var, but not "
                 "'accumulated_stage_var', or vice versa. Either none or both have to be present."
             )
+            print(
+                found_step_input_var,
+                found_accumulated_stage_var,
+                found_stage_output_var,
+            )
 
-    assert len(translation_metadata) == len(time_integration_quantity_list) and len(
-        quantity_metadata
-    ) == len(
-        time_integration_quantity_list
-    ), "There are some passed time integration quantity tags that have no tagged variables in the stage problem."
     return (
         array_size,
         translation_metadata,
@@ -182,6 +182,7 @@ def add_postprocessing_metadata(
                 "shape": 0,
                 "global_shape": 0,
                 "local": False,
+                "distributed": False,
                 "start_index": 0,
                 "end_index": 0,
                 "functionally_integrated": False,
@@ -209,6 +210,7 @@ def add_postprocessing_metadata(
             get_remote=False,
         )
         found_postproc_input_var = 0
+        # At least one variable will be found in here, so found_postproc_input_var will be greater than zero
         for detailed_var, detailed_data in detailed_local_quantity.items():
             if "postproc_input_var" in detailed_data["tags"]:
                 found_postproc_input_var += 1
@@ -295,11 +297,6 @@ def add_postprocessing_metadata(
                 found_postproc_output_var >= 1
             ), f"For quantity {quantity}, there is no inner variable tagged with 'postproc_output_vars'."
 
-    assert len(translation_metadata) == len(time_integration_quantity_list) + len(
-        postprocessing_quantity_list
-    ) and len(quantity_metadata) == len(time_integration_quantity_list) + len(
-        postprocessing_quantity_list
-    ), "There are some passed postprocessing quantity tags that have no tagged variables in the stage problem."
     return (
         array_size,
         translation_metadata,

--- a/src/rkopenmdao/postprocessing.py
+++ b/src/rkopenmdao/postprocessing.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-module-docstring
 
+from __future__ import annotations
+
 from collections.abc import Callable
 import numpy as np
 

--- a/src/rkopenmdao/postprocessing.py
+++ b/src/rkopenmdao/postprocessing.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-module-docstring
 
-from typing import Callable
+from collections.abc import Callable
 import numpy as np
 
 

--- a/src/rkopenmdao/postprocessing_computation_functors.py
+++ b/src/rkopenmdao/postprocessing_computation_functors.py
@@ -5,6 +5,7 @@ import numpy as np
 import openmdao.api as om
 
 from .errors import PostprocessingError
+from .metadata_extractor import TimeIntegrationMetadata
 
 
 class PostprocessingProblemComputeFunctor:
@@ -14,51 +15,48 @@ class PostprocessingProblemComputeFunctor:
     def __init__(
         self,
         postprocessing_problem: om.Problem,
-        quantity_metadata: dict,
-        translation_metadata: dict,
-        state_size: int,
-        postproc_size: int,
+        time_integration_metadata: TimeIntegrationMetadata,
     ):
         self.postprocessing_problem: om.Problem = postprocessing_problem
-        self.quantity_metadata: dict = quantity_metadata
-        self.translation_metadata: dict = translation_metadata
-        self.state_size = state_size
-        self.postproc_size = postproc_size
+        self.time_integration_metadata: TimeIntegrationMetadata = (
+            time_integration_metadata
+        )
 
     def __call__(self, input_vector: np.ndarray) -> np.ndarray:
         self.fill_problem_data(input_vector)
         self.postprocessing_problem.model.run_solve_nonlinear()
-        postproc_state = np.zeros(self.postproc_size)
+        postproc_state = np.zeros(
+            self.time_integration_metadata.postprocessing_array_size
+        )
         self.get_problem_data(postproc_state)
         return postproc_state
 
     def fill_problem_data(self, input_vector):
         """Write data into the internal nonlinear vectors of the owned problem."""
         _, outputs, _ = self.postprocessing_problem.model.get_nonlinear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
+        for quantity in self.time_integration_metadata.quantity_list:
             if (
-                metadata["type"] == "time_integration"
-                and metadata["local"]
-                and self.translation_metadata[quantity]["postproc_input_var"]
-                is not None
+                quantity.type == "time_integration"
+                and quantity.array_metadata.local
+                and quantity.translation_metadata.postproc_input_var is not None
             ):
-                start = metadata["start_index"]
-                end = metadata["end_index"]
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
                 outputs[
                     self.postprocessing_problem.model.get_source(
-                        self.translation_metadata[quantity]["postproc_input_var"]
+                        quantity.translation_metadata.postproc_input_var
                     )
-                ] = (input_vector[start:end].reshape(metadata["shape"]),)
+                ] = (input_vector[start:end].reshape(quantity.array_metadata.shape),)
 
     def get_problem_data(self, postproc_state: np.ndarray):
         """Extract data from the internal nonlinear vectors of the owned problem."""
         _, outputs, _ = self.postprocessing_problem.model.get_nonlinear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "postprocessing" and metadata["local"]:
-                start = metadata["start_index"]
-                end = metadata["end_index"]
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "postprocessing" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
                 postproc_state[start:end] = outputs[
-                    self.translation_metadata[quantity]["postproc_output_var"]
+                    quantity.translation_metadata.postproc_output_var
                 ].flatten()
 
 
@@ -70,18 +68,14 @@ class PostprocessingProblemComputeJacvecFunctor:
     def __init__(
         self,
         postprocessing_problem: om.Problem,
-        quantity_metadata: dict,
-        translation_metadata: dict,
-        state_size: int,
-        postproc_size: int,
+        time_integration_metadata: TimeIntegrationMetadata,
         of_vars: list,
         wrt_vars: list,
     ):
         self.postprocessing_problem: om.Problem = postprocessing_problem
-        self.quantity_metadata: dict = quantity_metadata
-        self.translation_metadata: dict = translation_metadata
-        self.state_size = state_size
-        self.postproc_size = postproc_size
+        self.time_integration_metadata: TimeIntegrationMetadata = (
+            time_integration_metadata
+        )
         self.of_vars = of_vars
         self.wrt_vars = wrt_vars
 
@@ -95,7 +89,9 @@ class PostprocessingProblemComputeJacvecFunctor:
             self.postprocessing_problem.model.run_solve_linear(
                 vec_names=["linear"], mode="fwd"
             )
-        postproc_perturbations = np.zeros(self.postproc_size)
+        postproc_perturbations = np.zeros(
+            self.time_integration_metadata.postprocessing_array_size
+        )
         self.get_problem_data(postproc_perturbations)
         return postproc_perturbations
 
@@ -103,30 +99,29 @@ class PostprocessingProblemComputeJacvecFunctor:
         """Write data into the internal linear vectors of the owned problem."""
         (_, _, d_residuals) = self.postprocessing_problem.model.get_linear_vectors()
         d_residuals.asarray()[:] *= 0.0
-        for quantity, metadata in self.quantity_metadata.items():
+        for quantity in self.time_integration_metadata.quantity_list:
             if (
-                metadata["type"] == "time_integration"
-                and metadata["local"]
-                and self.translation_metadata[quantity]["postproc_input_var"]
-                is not None
+                quantity.type == "time_integration"
+                and quantity.array_metadata.local
+                and quantity.translation_metadata.postproc_input_var is not None
             ):
-                start = metadata["start_index"]
-                end = metadata["end_index"]
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
                 d_residuals[
                     self.postprocessing_problem.model.get_source(
-                        self.translation_metadata[quantity]["postproc_input_var"]
+                        quantity.translation_metadata.postproc_input_var
                     )
-                ] = -input_vector[start:end].reshape(metadata["shape"])
+                ] = -input_vector[start:end].reshape(quantity.array_metadata.shape)
 
     def get_problem_data(self, postproc_perturbations: np.ndarray):
         """Extract data from the internal linear vectors of the owned problem."""
         _, d_outputs, _ = self.postprocessing_problem.model.get_linear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "postprocessing" and metadata["local"]:
-                start = metadata["start_index"]
-                end = metadata["end_index"]
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "postprocessing" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
                 postproc_perturbations[start:end] = d_outputs[
-                    self.translation_metadata[quantity]["postproc_output_var"]
+                    quantity.translation_metadata.postproc_output_var
                 ].flatten()
 
     def linearize(self, inputs=None, outputs=None):
@@ -154,18 +149,14 @@ class PostprocessingProblemComputeTransposeJacvecFunctor:
     def __init__(
         self,
         postprocessing_problem: om.Problem,
-        quantity_metadata: dict,
-        translation_metadata: dict,
-        state_size: int,
-        postproc_size: int,
+        time_integration_metadata: TimeIntegrationMetadata,
         of_vars: list,
         wrt_vars: list,
     ):
         self.postprocessing_problem: om.Problem = postprocessing_problem
-        self.quantity_metadata: dict = quantity_metadata
-        self.translation_metadata: dict = translation_metadata
-        self.state_size = state_size
-        self.postproc_size = postproc_size
+        self.time_integration_metadata: TimeIntegrationMetadata = (
+            time_integration_metadata
+        )
         self.of_vars = of_vars
         self.wrt_vars = wrt_vars
 
@@ -179,7 +170,9 @@ class PostprocessingProblemComputeTransposeJacvecFunctor:
             self.postprocessing_problem.model.run_solve_linear(
                 vec_names=["linear"], mode="rev"
             )
-        input_perturbations = np.zeros(self.state_size)
+        input_perturbations = np.zeros(
+            self.time_integration_metadata.time_integration_array_size
+        )
         self.get_problem_data(input_perturbations)
         return input_perturbations
 
@@ -187,29 +180,30 @@ class PostprocessingProblemComputeTransposeJacvecFunctor:
         """Write data into the internal linear vectors of the owned problem."""
         _, d_outputs, _ = self.postprocessing_problem.model.get_linear_vectors()
         d_outputs.asarray()[:] *= 0
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "postprocessing" and metadata["local"]:
-                start = metadata["start_index"]
-                end = metadata["end_index"]
-                d_outputs[
-                    self.translation_metadata[quantity]["postproc_output_var"]
-                ] = -postproc_perturbations[start:end].reshape(metadata["shape"])
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "postprocessing" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
+                d_outputs[quantity.translation_metadata.postproc_output_var] = (
+                    -postproc_perturbations[start:end].reshape(
+                        quantity.array_metadata.shape
+                    )
+                )
 
     def get_problem_data(self, input_perturbations: np.ndarray):
         """Extract data from the internal linear vectors of the owned problem."""
         _, _, d_residuals = self.postprocessing_problem.model.get_linear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
+        for quantity in self.time_integration_metadata.quantity_list:
             if (
-                metadata["type"] == "time_integration"
-                and metadata["local"]
-                and self.translation_metadata[quantity]["postproc_input_var"]
-                is not None
+                quantity.type == "time_integration"
+                and quantity.array_metadata.local
+                and quantity.translation_metadata.postproc_input_var is not None
             ):
-                start = metadata["start_index"]
-                end = metadata["end_index"]
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
                 input_perturbations[start:end] = d_residuals[
                     self.postprocessing_problem.model.get_source(
-                        self.translation_metadata[quantity]["postproc_input_var"]
+                        quantity.translation_metadata.postproc_input_var
                     )
                 ].flatten()
 

--- a/src/rkopenmdao/postprocessing_computation_functors.py
+++ b/src/rkopenmdao/postprocessing_computation_functors.py
@@ -38,6 +38,7 @@ class PostprocessingProblemComputeFunctor:
         for quantity, metadata in self.quantity_metadata.items():
             if (
                 metadata["type"] == "time_integration"
+                and metadata["local"]
                 and self.translation_metadata[quantity]["postproc_input_var"]
                 is not None
             ):
@@ -53,7 +54,7 @@ class PostprocessingProblemComputeFunctor:
         """Extract data from the internal nonlinear vectors of the owned problem."""
         _, outputs, _ = self.postprocessing_problem.model.get_nonlinear_vectors()
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "postprocessing":
+            if metadata["type"] == "postprocessing" and metadata["local"]:
                 start = metadata["start_index"]
                 end = metadata["end_index"]
                 postproc_state[start:end] = outputs[
@@ -105,6 +106,7 @@ class PostprocessingProblemComputeJacvecFunctor:
         for quantity, metadata in self.quantity_metadata.items():
             if (
                 metadata["type"] == "time_integration"
+                and metadata["local"]
                 and self.translation_metadata[quantity]["postproc_input_var"]
                 is not None
             ):
@@ -120,7 +122,7 @@ class PostprocessingProblemComputeJacvecFunctor:
         """Extract data from the internal linear vectors of the owned problem."""
         _, d_outputs, _ = self.postprocessing_problem.model.get_linear_vectors()
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "postprocessing":
+            if metadata["type"] == "postprocessing" and metadata["local"]:
                 start = metadata["start_index"]
                 end = metadata["end_index"]
                 postproc_perturbations[start:end] = d_outputs[
@@ -186,7 +188,7 @@ class PostprocessingProblemComputeTransposeJacvecFunctor:
         _, d_outputs, _ = self.postprocessing_problem.model.get_linear_vectors()
         d_outputs.asarray()[:] *= 0
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "postprocessing":
+            if metadata["type"] == "postprocessing" and metadata["local"]:
                 start = metadata["start_index"]
                 end = metadata["end_index"]
                 d_outputs[
@@ -199,6 +201,7 @@ class PostprocessingProblemComputeTransposeJacvecFunctor:
         for quantity, metadata in self.quantity_metadata.items():
             if (
                 metadata["type"] == "time_integration"
+                and metadata["local"]
                 and self.translation_metadata[quantity]["postproc_input_var"]
                 is not None
             ):

--- a/src/rkopenmdao/runge_kutta_integrator.py
+++ b/src/rkopenmdao/runge_kutta_integrator.py
@@ -581,17 +581,17 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
                     if np.isnan(
                         f[quantity][str(step)][
                             np.unravel_index(
-                                metadata["local_indices_start"],
+                                metadata["global_start_index"],
                                 metadata["global_shape"],
                             )
                         ]
                     ):
                         start_tuple = np.unravel_index(
-                            metadata["local_indices_start"],
+                            metadata["global_start_index"],
                             metadata["global_shape"],
                         )
                         end_tuple = np.unravel_index(
-                            metadata["local_indices_end"] - 1,
+                            metadata["global_end_index"] - 1,
                             metadata["global_shape"],
                         )
                         access_list = []
@@ -606,17 +606,17 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
                     if np.isnan(
                         f[quantity][str(step)][
                             np.unravel_index(
-                                metadata["local_indices_start"],
+                                metadata["global_start_index"],
                                 metadata["global_shape"],
                             )
                         ]
                     ):
                         start_tuple = np.unravel_index(
-                            metadata["local_indices_start"],
+                            metadata["global_start_index"],
                             metadata["global_shape"],
                         )
                         end_tuple = np.unravel_index(
-                            metadata["local_indices_end"] - 1,
+                            metadata["global_end_index"] - 1,
                             metadata["global_shape"],
                         )
                         access_list = []
@@ -650,9 +650,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
             start_functional = self._quantity_metadata[quantity][
                 "functional_start_index"
             ]
-            end_functional = self._quantity_metadata[quantity][
-                "functional_end_index"
-            ]
+            end_functional = self._quantity_metadata[quantity]["functional_end_index"]
             if self._quantity_metadata[quantity]["type"] == "time_integration":
                 start_time_stepping = self._quantity_metadata[quantity]["start_index"]
                 end_time_stepping = self._quantity_metadata[quantity]["end_index"]

--- a/src/rkopenmdao/runge_kutta_integrator.py
+++ b/src/rkopenmdao/runge_kutta_integrator.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-module-docstring, protected-access
 
-from typing import Optional
+from __future__ import annotations
+
 import h5py
 import numpy as np
 import openmdao.api as om
@@ -30,9 +31,6 @@ from .metadata_extractor import (
     add_functional_metadata,
     add_distributivity_information,
     TimeIntegrationMetadata,
-    Quantity,
-    ArrayMetadata,
-    TranslationMetadata,
 )
 
 
@@ -53,33 +51,29 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
     _of_vars_postproc: list
     _wrt_vars_postproc: list
 
-    _runge_kutta_scheme: Optional[RungeKuttaScheme]
-    _serialized_state: Optional[np.ndarray]
-    _accumulated_stages: Optional[np.ndarray]
-    _stage_cache: Optional[np.ndarray]
-    _serialized_state_perturbations: Optional[np.ndarray]
-    _serialized_state_perturbations_from_functional: Optional[np.ndarray]
-    _accumulated_stage_perturbations: Optional[np.ndarray]
-    _stage_perturbations_cache: Optional[np.ndarray]
+    _runge_kutta_scheme: RungeKuttaScheme | None
+    _serialized_state: np.ndarray | None
+    _accumulated_stages: np.ndarray | None
+    _stage_cache: np.ndarray | None
+    _serialized_state_perturbations: np.ndarray | None
+    _serialized_state_perturbations_from_functional: np.ndarray | None
+    _accumulated_stage_perturbations: np.ndarray | None
+    _stage_perturbations_cache: np.ndarray | None
 
-    _postprocessor: Optional[Postprocessor]
-    _postprocessing_state: Optional[np.ndarray]
-    _postprocessing_state_perturbations: Optional[np.ndarray]
+    _postprocessor: Postprocessor | None
+    _postprocessing_state: np.ndarray | None
+    _postprocessing_state_perturbations: np.ndarray | None
 
-    _functional_part: Optional[np.ndarray]
-    _functional_part_perturbations: Optional[np.ndarray]
+    _functional_part: np.ndarray | None
+    _functional_part_perturbations: np.ndarray | None
 
-    _time_integration_metadata: TimeIntegrationMetadata
-
-    _numpy_array_size: int
-    _numpy_postproc_size: int
-    _numpy_functional_size: int
+    _time_integration_metadata: TimeIntegrationMetadata | None
 
     _cached_input: np.ndarray
 
     _disable_write_out: bool
 
-    _checkpointer: Optional[CheckpointInterface]
+    _checkpointer: CheckpointInterface | None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -104,6 +98,8 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
 
         self._functional_part = None
         self._functional_part_perturbations = None
+
+        self._time_integration_metadata = None
 
         self._cached_input = np.full(0, np.nan)
         self._disable_write_out = False

--- a/src/rkopenmdao/runge_kutta_integrator.py
+++ b/src/rkopenmdao/runge_kutta_integrator.py
@@ -24,7 +24,6 @@ from .postprocessing_computation_functors import (
 )
 from .checkpoint_interface.checkpoint_interface import CheckpointInterface
 from .checkpoint_interface.no_checkpointer import NoCheckpointer
-from .errors import SetupError
 from .metadata_extractor import (
     extract_time_integration_metadata,
     add_postprocessing_metadata,

--- a/src/rkopenmdao/runge_kutta_integrator.py
+++ b/src/rkopenmdao/runge_kutta_integrator.py
@@ -307,7 +307,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
                         shape=quantity.array_metadata.shape,
                         val=(
                             time_stage_problem.get_val(
-                                quantity.translation_metadata.step_input_var,  # get_remote=False
+                                quantity.translation_metadata.step_input_var,
                             )
                             if quantity.translation_metadata.step_input_var is not None
                             else np.zeros(quantity.array_metadata.shape)

--- a/src/rkopenmdao/runge_kutta_scheme.py
+++ b/src/rkopenmdao/runge_kutta_scheme.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-module-docstring
 
-from typing import Callable, Tuple
+from __future__ import annotations
+from collections.abc import Callable
 
 import numpy as np
 
@@ -28,7 +29,7 @@ class RungeKuttaScheme:
         # butcher_diagonal_element
         # -> stage_perturbation
         stage_computation_functor_transposed_jacvec: Callable[
-            [np.ndarray, float, float, float], Tuple[np.ndarray, np.ndarray]
+            [np.ndarray, float, float, float], tuple[np.ndarray, np.ndarray]
         ],
         # stage_perturbation, stage_time, delta_t, butcher_diagonal_element
         # -> old_state_perturbation, accumulated_stages_perturbation
@@ -88,7 +89,7 @@ class RungeKuttaScheme:
         old_time: float,
         old_state_perturbation: np.ndarray,
         accumulated_stages_perturbation: np.ndarray,
-        **linearization_args
+        **linearization_args,
     ) -> np.ndarray:
         """Computes the matrix-vector-product of the jacobian of the stage wrt. to the
         old state and the accumulated stages."""
@@ -136,8 +137,8 @@ class RungeKuttaScheme:
         delta_t: float,
         old_time: float,
         joined_perturbation: np.ndarray,
-        **linearization_args
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        **linearization_args,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Computes the matrix-vector-product of the transposed of the jacobian of the
         stage wrt. to the old state and the accumulated stages."""
         if hasattr(self.stage_computation_functor_transposed_jacvec, "linearize"):

--- a/src/rkopenmdao/time_stage_problem_computation_functors.py
+++ b/src/rkopenmdao/time_stage_problem_computation_functors.py
@@ -1,7 +1,7 @@
 """Wrapper classes to make a openMDAO problem modelling a time stage for the
 RungeKuttaIntegrator usable with the RungeKuttaScheme class."""
 
-from typing import Tuple
+from __future__ import annotations
 
 import numpy as np
 import openmdao.api as om
@@ -209,7 +209,7 @@ class TimeStageProblemComputeTransposeJacvecFunctor:
         stage_time: float,
         delta_t: float,
         butcher_diagonal_element: float,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         self.integration_control.stage_time = stage_time
         self.integration_control.butcher_diagonal_element = butcher_diagonal_element
         self.time_stage_problem.model.run_linearize()

--- a/src/rkopenmdao/time_stage_problem_computation_functors.py
+++ b/src/rkopenmdao/time_stage_problem_computation_functors.py
@@ -8,6 +8,7 @@ import openmdao.api as om
 
 from .integration_control import IntegrationControl
 from .errors import TimeStageError
+from .metadata_extractor import TimeIntegrationMetadata
 
 
 class TimeStageProblemComputeFunctor:
@@ -18,13 +19,13 @@ class TimeStageProblemComputeFunctor:
         self,
         time_stage_problem: om.Problem,
         integration_control: IntegrationControl,
-        quantity_metadata: dict,
-        translation_metadata: dict,
+        time_integration_metadata: TimeIntegrationMetadata,
     ):
         self.time_stage_problem: om.Problem = time_stage_problem
         self.integration_control: IntegrationControl = integration_control
-        self.quantity_metadata: dict = quantity_metadata
-        self.translation_metadata: dict = translation_metadata
+        self.time_integration_metadata: TimeIntegrationMetadata = (
+            time_integration_metadata
+        )
 
     def __call__(
         self,
@@ -48,31 +49,33 @@ class TimeStageProblemComputeFunctor:
     def fill_problem_data(self, old_state: np.ndarray, accumulated_stage: np.ndarray):
         """Fills internal OpenMDAO vectors."""
         _, outputs, _ = self.time_stage_problem.model.get_nonlinear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration" and metadata["local"]:
-                start = metadata["start_index"]
-                end = metadata["end_index"]
-                if self.translation_metadata[quantity]["step_input_var"] is not None:
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "time_integration" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
+                if quantity.translation_metadata.step_input_var is not None:
                     outputs[
                         self.time_stage_problem.model.get_source(
-                            self.translation_metadata[quantity]["step_input_var"]
+                            quantity.translation_metadata.step_input_var
                         )
-                    ] = old_state[start:end].reshape(metadata["shape"])
+                    ] = old_state[start:end].reshape(quantity.array_metadata.shape)
                     outputs[
                         self.time_stage_problem.model.get_source(
-                            self.translation_metadata[quantity]["accumulated_stage_var"]
+                            quantity.translation_metadata.accumulated_stage_var
                         )
-                    ] = accumulated_stage[start:end].reshape(metadata["shape"])
+                    ] = accumulated_stage[start:end].reshape(
+                        quantity.array_metadata.shape
+                    )
 
     def get_problem_data(self, stage_state: np.ndarray):
         """Extract data from the output vectors of the owned problem."""
         _, outputs, _ = self.time_stage_problem.model.get_nonlinear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration" and metadata["local"]:
-                start = metadata["start_index"]
-                end = metadata["end_index"]
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "time_integration" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
                 stage_state[start:end] = outputs[
-                    self.translation_metadata[quantity]["stage_output_var"]
+                    quantity.translation_metadata.stage_output_var
                 ].flatten()
 
 
@@ -85,15 +88,15 @@ class TimeStageProblemComputeJacvecFunctor:
         self,
         time_stage_problem: om.Problem,
         integration_control: IntegrationControl,
-        quantity_metadata: dict,
-        translation_metadata: dict,
+        time_integration_metadata: TimeIntegrationMetadata,
         of_vars: list,
         wrt_vars: list,
     ):
         self.time_stage_problem: om.Problem = time_stage_problem
         self.integration_control: IntegrationControl = integration_control
-        self.quantity_metadata: dict = quantity_metadata
-        self.translation_metadata: dict = translation_metadata
+        self.time_integration_metadata: TimeIntegrationMetadata = (
+            time_integration_metadata
+        )
         self.of_vars = of_vars
         self.wrt_vars = wrt_vars
 
@@ -130,34 +133,36 @@ class TimeStageProblemComputeJacvecFunctor:
         """Fills d_residuals of the time_stage_problem to prepare for jacvec product."""
         (_, _, d_residuals) = self.time_stage_problem.model.get_linear_vectors()
         d_residuals.asarray()[:] *= 0.0
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration" and metadata["local"]:
-                start = metadata["start_index"]
-                end = start + np.prod(metadata["shape"])
-                if self.translation_metadata[quantity]["step_input_var"] is not None:
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "time_integration" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
+                if quantity.translation_metadata.step_input_var is not None:
                     d_residuals[
                         self.time_stage_problem.model.get_source(
-                            self.translation_metadata[quantity]["step_input_var"]
+                            quantity.translation_metadata.step_input_var
                         )
-                    ] = -old_state_perturbation[start:end].reshape(metadata["shape"])
+                    ] = -old_state_perturbation[start:end].reshape(
+                        quantity.array_metadata.shape
+                    )
                     d_residuals[
                         self.time_stage_problem.model.get_source(
-                            self.translation_metadata[quantity]["accumulated_stage_var"]
+                            quantity.translation_metadata.accumulated_stage_var
                         )
                     ] = -accumulated_stage_perturbation[start:end].reshape(
-                        metadata["shape"]
+                        quantity.array_metadata.shape
                     )
 
     def get_problem_data(self, stage_perturbation: np.ndarray):
         """Extracts the result of the jacvec product from d_outputs of the
         time_stage_problem."""
         _, d_outputs, _ = self.time_stage_problem.model.get_linear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration" and metadata["local"]:
-                start = metadata["start_index"]
-                end = start + np.prod(metadata["shape"])
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "time_integration" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
                 stage_perturbation[start:end] = d_outputs[
-                    self.translation_metadata[quantity]["stage_output_var"]
+                    quantity.translation_metadata.stage_output_var
                 ].flatten()
 
     def linearize(self, inputs=None, outputs=None):
@@ -186,15 +191,15 @@ class TimeStageProblemComputeTransposeJacvecFunctor:
         self,
         time_stage_problem: om.Problem,
         integration_control: IntegrationControl,
-        quantity_metadata: dict,
-        translation_metadata: dict,
+        time_integration_metadata: TimeIntegrationMetadata,
         of_vars: list,
         wrt_vars: list,
     ):
         self.time_stage_problem: om.Problem = time_stage_problem
         self.integration_control: IntegrationControl = integration_control
-        self.quantity_metadata: dict = quantity_metadata
-        self.translation_metadata: dict = translation_metadata
+        self.time_integration_metadata: TimeIntegrationMetadata = (
+            time_integration_metadata
+        )
         self.of_vars = of_vars
         self.wrt_vars = wrt_vars
 
@@ -226,12 +231,14 @@ class TimeStageProblemComputeTransposeJacvecFunctor:
         """Fills d_outputs of the time_stage_problem to prepare for jacvec product."""
         _, d_outputs, _ = self.time_stage_problem.model.get_linear_vectors()
         d_outputs.asarray()[:] *= 0
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration" and metadata["local"]:
-                start = metadata["start_index"]
-                end = start + np.prod(metadata["shape"])
-                d_outputs[self.translation_metadata[quantity]["stage_output_var"]] = (
-                    -stage_perturbation[start:end].reshape(metadata["shape"])
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "time_integration" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
+                d_outputs[quantity.translation_metadata.stage_output_var] = (
+                    -stage_perturbation[start:end].reshape(
+                        quantity.array_metadata.shape
+                    )
                 )
 
     def get_problem_data(
@@ -242,19 +249,19 @@ class TimeStageProblemComputeTransposeJacvecFunctor:
         """Extracts the result of the jacvec product from d_residuals of the
         time_stage_problem."""
         _, _, d_residuals = self.time_stage_problem.model.get_linear_vectors()
-        for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration" and metadata["local"]:
-                start = metadata["start_index"]
-                end = start + np.prod(metadata["shape"])
-                if self.translation_metadata[quantity]["step_input_var"] is not None:
+        for quantity in self.time_integration_metadata.quantity_list:
+            if quantity.type == "time_integration" and quantity.array_metadata.local:
+                start = quantity.array_metadata.start_index
+                end = quantity.array_metadata.end_index
+                if quantity.translation_metadata.step_input_var is not None:
                     old_state_perturbation[start:end] = d_residuals[
                         self.time_stage_problem.model.get_source(
-                            self.translation_metadata[quantity]["step_input_var"]
+                            quantity.translation_metadata.step_input_var
                         )
                     ].flatten()
                     accumulated_stage_perturbation[start:end] = d_residuals[
                         self.time_stage_problem.model.get_source(
-                            self.translation_metadata[quantity]["accumulated_stage_var"]
+                            quantity.translation_metadata.accumulated_stage_var
                         )
                     ].flatten()
 

--- a/src/rkopenmdao/time_stage_problem_computation_functors.py
+++ b/src/rkopenmdao/time_stage_problem_computation_functors.py
@@ -49,9 +49,9 @@ class TimeStageProblemComputeFunctor:
         """Fills internal OpenMDAO vectors."""
         _, outputs, _ = self.time_stage_problem.model.get_nonlinear_vectors()
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration":
+            if metadata["type"] == "time_integration" and metadata["local"]:
                 start = metadata["start_index"]
-                end = start + np.prod(metadata["shape"])
+                end = metadata["end_index"]
                 if self.translation_metadata[quantity]["step_input_var"] is not None:
                     outputs[
                         self.time_stage_problem.model.get_source(
@@ -68,9 +68,9 @@ class TimeStageProblemComputeFunctor:
         """Extract data from the output vectors of the owned problem."""
         _, outputs, _ = self.time_stage_problem.model.get_nonlinear_vectors()
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration":
+            if metadata["type"] == "time_integration" and metadata["local"]:
                 start = metadata["start_index"]
-                end = start + np.prod(metadata["shape"])
+                end = metadata["end_index"]
                 stage_state[start:end] = outputs[
                     self.translation_metadata[quantity]["stage_output_var"]
                 ].flatten()
@@ -131,7 +131,7 @@ class TimeStageProblemComputeJacvecFunctor:
         (_, _, d_residuals) = self.time_stage_problem.model.get_linear_vectors()
         d_residuals.asarray()[:] *= 0.0
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration":
+            if metadata["type"] == "time_integration" and metadata["local"]:
                 start = metadata["start_index"]
                 end = start + np.prod(metadata["shape"])
                 if self.translation_metadata[quantity]["step_input_var"] is not None:
@@ -153,7 +153,7 @@ class TimeStageProblemComputeJacvecFunctor:
         time_stage_problem."""
         _, d_outputs, _ = self.time_stage_problem.model.get_linear_vectors()
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration":
+            if metadata["type"] == "time_integration" and metadata["local"]:
                 start = metadata["start_index"]
                 end = start + np.prod(metadata["shape"])
                 stage_perturbation[start:end] = d_outputs[
@@ -227,7 +227,7 @@ class TimeStageProblemComputeTransposeJacvecFunctor:
         _, d_outputs, _ = self.time_stage_problem.model.get_linear_vectors()
         d_outputs.asarray()[:] *= 0
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration":
+            if metadata["type"] == "time_integration" and metadata["local"]:
                 start = metadata["start_index"]
                 end = start + np.prod(metadata["shape"])
                 d_outputs[self.translation_metadata[quantity]["stage_output_var"]] = (
@@ -243,7 +243,7 @@ class TimeStageProblemComputeTransposeJacvecFunctor:
         time_stage_problem."""
         _, _, d_residuals = self.time_stage_problem.model.get_linear_vectors()
         for quantity, metadata in self.quantity_metadata.items():
-            if metadata["type"] == "time_integration":
+            if metadata["type"] == "time_integration" and metadata["local"]:
                 start = metadata["start_index"]
                 end = start + np.prod(metadata["shape"])
                 if self.translation_metadata[quantity]["step_input_var"] is not None:

--- a/tests/metadata_extractor_test.py
+++ b/tests/metadata_extractor_test.py
@@ -1,0 +1,772 @@
+import openmdao.api as om
+from numpy.lib.function_base import extract
+from openmdao.utils.assert_utils import assert_check_totals, assert_check_partials
+import pytest
+import numpy as np
+from mpi4py import MPI
+from rkopenmdao.metadata_extractor import *
+
+
+class MetadataTestComponent(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare(
+            "input_dict", types=dict, default={}, desc="Inputs with tags"
+        )
+        self.options.declare(
+            "output_dict", types=dict, default={}, desc="Outputs with tags"
+        )
+
+    def setup(self):
+        for var, metadata in self.options["input_dict"].items():
+            self.add_input(
+                var,
+                tags=metadata["tags"],
+                shape=metadata["shape"],
+                distributed=metadata["distributed"],
+            )
+        for var, metadata in self.options["output_dict"].items():
+            self.add_output(
+                var,
+                tags=metadata["tags"],
+                shape=metadata["shape"],
+                distributed=metadata["distributed"],
+            )
+
+
+def basic_test_problem():
+    input_dict = {
+        "x_old": {
+            "tags": ["step_input_var", "x"],
+            "shape": (5, 2),
+            "distributed": False,
+        },
+        "x_acc_stages": {
+            "tags": ["accumulated_stage_var", "x"],
+            "shape": (5, 2),
+            "distributed": False,
+        },
+    }
+    output_dict = {
+        "x_update": {
+            "tags": ["stage_output_var", "x"],
+            "shape": (5, 2),
+            "distributed": False,
+        },
+    }
+    test_comp = MetadataTestComponent(input_dict=input_dict, output_dict=output_dict)
+    prob = om.Problem()
+    prob.model.add_subsystem("test_comp", test_comp, promotes=["*"])
+    prob.setup()
+    return prob
+
+
+def test_metadata_non_parallel_correct():
+    prob = basic_test_problem()
+
+    array_size, translation_metadata, quantity_metadata = (
+        extract_time_integration_metadata(prob, ["x"])
+    )
+
+    assert array_size == 10
+    assert translation_metadata == {
+        "x": {
+            "step_input_var": "test_comp.x_old",
+            "accumulated_stage_var": "test_comp.x_acc_stages",
+            "stage_output_var": "test_comp.x_update",
+            "postproc_input_var": None,
+        }
+    }
+    assert quantity_metadata == {
+        "x": {
+            "type": "time_integration",
+            "shape": (5, 2),
+            "global_shape": (5, 2),
+            "local": True,
+            "distributed": False,
+            "start_index": 0,
+            "end_index": 10,
+            "functionally_integrated": False,
+            "functional_start_index": 0,
+            "functional_end_index": 0,
+            "global_start_index": 0,
+            "global_end_index": 10,
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "input_dict, output_dict, quantity_list, error_message",
+    [
+        (
+            {
+                "x_old": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_acc_stages": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_update_2": {
+                    "tags": ["stage_output_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["x"],
+            "For quantity x, there is more than one inner variable tagged with 'stage_output_var'.",
+        ),
+        (
+            {
+                "x_old": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_old_2": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_acc_stages": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["x"],
+            "For quantity x, there is more than one inner variable tagged with 'step_input_var'.",
+        ),
+        (
+            {
+                "x_old": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_acc_stages": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_acc_stages_2": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["x"],
+            "For quantity x, there is more than one inner variable tagged with 'accumulated_stage_var'.",
+        ),
+        (
+            {
+                "x_old": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_acc_stages": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var_error", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["x"],
+            "For quantity x, there is no inner variable tagged with 'stage_output_var'.",
+        ),
+        (
+            {
+                "x_old": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["x"],
+            "For quantity x, there is either a variable tagged for 'step_input_var, but not "
+            "'accumulated_stage_var', or vice versa. Either none or both have to be present.",
+        ),
+        (
+            {
+                "x_acc_stages": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["x"],
+            "For quantity x, there is either a variable tagged for 'step_input_var, but not "
+            "'accumulated_stage_var', or vice versa. Either none or both have to be present.",
+        ),
+        (
+            {
+                "x_old": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_acc_stages": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var", "x", "y"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["x", "y"],
+            "Variable test_comp.x_update either has two time integration quantity tags, or 'stage_output_var' was "
+            "used as quantity tag. Both are forbidden. Tags of test_comp.x_update intersected with time integration "
+            "quantities: ({'y', 'x'}|{'x', 'y'}).",
+        ),
+        (
+            {
+                "x_old": {
+                    "tags": ["step_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x_acc_stages": {
+                    "tags": ["accumulated_stage_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "x_update": {
+                    "tags": ["stage_output_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            ["stage_output_var", "x"],
+            "Variable test_comp.x_update either has two time integration quantity tags, or 'stage_output_var' was "
+            "used as quantity tag. Both are forbidden. Tags of test_comp.x_update intersected with time integration "
+            "quantities: ({'x', 'stage_output_var'}|{'stage_output_var', 'x'}).",
+        ),
+    ],
+)
+def test_metadata_non_parallel_incorrect(
+    input_dict, output_dict, quantity_list, error_message
+):
+    test_comp = MetadataTestComponent(input_dict=input_dict, output_dict=output_dict)
+    prob = om.Problem()
+    prob.model.add_subsystem("test_comp", test_comp, promotes=["*"])
+    prob.setup()
+    with pytest.raises(AssertionError, match=error_message):
+        extract_time_integration_metadata(prob, quantity_list)
+
+
+def test_metadata_functional_correct():
+    prob = basic_test_problem()
+    _, _, quantity_metadata = extract_time_integration_metadata(prob, ["x"])
+    functional_size, quantity_metadata = add_functional_metadata(
+        ["x"], quantity_metadata
+    )
+    assert functional_size == 10
+    assert quantity_metadata == {
+        "x": {
+            "type": "time_integration",
+            "shape": (5, 2),
+            "global_shape": (5, 2),
+            "local": True,
+            "distributed": False,
+            "start_index": 0,
+            "end_index": 10,
+            "functionally_integrated": True,
+            "functional_start_index": 0,
+            "functional_end_index": 10,
+            "global_start_index": 0,
+            "global_end_index": 10,
+        }
+    }
+
+
+def test_metadata_functional_incorrect():
+    prob = basic_test_problem()
+    _, _, quantity_metadata = extract_time_integration_metadata(prob, ["x"])
+    with pytest.raises(
+        AssertionError,
+        match="Some functional requires a quantity that is part of neither the time integration nor postprocessing.",
+    ):
+        add_functional_metadata(["y"], quantity_metadata)
+
+
+def test_metadata_postprocessing_correct():
+    prob = basic_test_problem()
+    input_dict = {
+        "x": {
+            "tags": ["postproc_input_var", "x"],
+            "shape": (5, 2),
+            "distributed": False,
+        },
+    }
+    output_dict = {
+        "y": {
+            "tags": ["postproc_output_var", "y"],
+            "shape": (1, 2),
+            "distributed": False,
+        },
+    }
+    postproc_comp = MetadataTestComponent(
+        input_dict=input_dict, output_dict=output_dict
+    )
+    postproc_prob = om.Problem()
+    postproc_prob.model.add_subsystem("postproc_test", postproc_comp, promotes=["*"])
+    _, translation_metadata, quantity_metadata = extract_time_integration_metadata(
+        prob, ["x"]
+    )
+    postproc_prob.setup()
+
+    postproc_array_size, translation_metadata, quantity_metadata = (
+        add_postprocessing_metadata(
+            postproc_prob, ["x"], ["y"], quantity_metadata, translation_metadata
+        )
+    )
+
+    assert postproc_array_size == 2
+    assert translation_metadata == {
+        "x": {
+            "step_input_var": "test_comp.x_old",
+            "accumulated_stage_var": "test_comp.x_acc_stages",
+            "stage_output_var": "test_comp.x_update",
+            "postproc_input_var": "postproc_test.x",
+        },
+        "y": {
+            "postproc_output_var": "postproc_test.y",
+        },
+    }
+    assert quantity_metadata == {
+        "x": {
+            "type": "time_integration",
+            "shape": (5, 2),
+            "global_shape": (5, 2),
+            "local": True,
+            "distributed": False,
+            "start_index": 0,
+            "end_index": 10,
+            "functionally_integrated": False,
+            "functional_start_index": 0,
+            "functional_end_index": 0,
+            "global_start_index": 0,
+            "global_end_index": 10,
+        },
+        "y": {
+            "type": "postprocessing",
+            "shape": (1, 2),
+            "global_shape": (1, 2),
+            "local": True,
+            "distributed": False,
+            "start_index": 0,
+            "end_index": 2,
+            "functionally_integrated": False,
+            "functional_start_index": 0,
+            "functional_end_index": 0,
+            "global_start_index": 0,
+            "global_end_index": 2,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "input_dict, output_dict, quantity_list, error_message",
+    [
+        (
+            {
+                "x": {
+                    "tags": ["postproc_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+                "x'": {
+                    "tags": ["postproc_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "y": {
+                    "tags": ["postproc_output_var", "y"],
+                    "shape": (1, 2),
+                    "distributed": False,
+                },
+            },
+            ["y"],
+            "More than one variable with quantity tag x for 'postproc_input_var' in postprocessing_problem.",
+        ),
+        (
+            {
+                "x": {
+                    "tags": ["postproc_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "y": {
+                    "tags": ["postproc_output_var", "y", "z"],
+                    "shape": (1, 2),
+                    "distributed": False,
+                },
+            },
+            ["y", "z"],
+            "Variable postproc_test.y either has two postprocessing quantity tags, or 'postproc_output_var' was "
+            "used as quantity tag. Both are forbidden. Tags of postproc_test.y intersected with time integration "
+            "quantities: ({'y', 'z'}|{'z', 'y'}).",
+        ),
+        (
+            {
+                "x": {
+                    "tags": ["postproc_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "y": {
+                    "tags": [
+                        "postproc_output_var",
+                        "y",
+                    ],
+                    "shape": (1, 2),
+                    "distributed": False,
+                },
+            },
+            ["postproc_output_var", "y"],
+            "Variable postproc_test.y either has two postprocessing quantity tags, or 'postproc_output_var' was "
+            "used as quantity tag. Both are forbidden. Tags of postproc_test.y intersected with time integration "
+            "quantities: ({'y', 'postproc_output_var'}|{'postproc_output_var', 'y'}).",
+        ),
+        (
+            {
+                "x": {
+                    "tags": ["postproc_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "y": {
+                    "tags": [
+                        "postproc_output_var",
+                        "y",
+                    ],
+                    "shape": (1, 2),
+                    "distributed": False,
+                },
+                "y'": {
+                    "tags": [
+                        "postproc_output_var",
+                        "y",
+                    ],
+                    "shape": (1, 2),
+                    "distributed": False,
+                },
+            },
+            ["y"],
+            "For quantity y, there is more than one inner variable tagged with 'postproc_output_var'.",
+        ),
+        (
+            {
+                "x": {
+                    "tags": ["postproc_input_var", "x"],
+                    "shape": (5, 2),
+                    "distributed": False,
+                },
+            },
+            {
+                "y": {
+                    "tags": [
+                        "postproc_output_var_error",
+                        "y",
+                    ],
+                    "shape": (1, 2),
+                    "distributed": False,
+                },
+            },
+            ["y"],
+            "For quantity y, there is no inner variable tagged with 'postproc_output_vars'.",
+        ),
+    ],
+)
+def test_metadata_postprocessing_incorrect(
+    input_dict, output_dict, quantity_list, error_message
+):
+    prob = basic_test_problem()
+    postproc_comp = MetadataTestComponent(
+        input_dict=input_dict, output_dict=output_dict
+    )
+    postproc_prob = om.Problem()
+    postproc_prob.model.add_subsystem("postproc_test", postproc_comp, promotes=["*"])
+    _, translation_metadata, quantity_metadata = extract_time_integration_metadata(
+        prob, ["x"]
+    )
+    postproc_prob.setup()
+
+    with pytest.raises(AssertionError, match=error_message):
+        add_postprocessing_metadata(
+            postproc_prob, ["x"], quantity_list, quantity_metadata, translation_metadata
+        )
+
+
+@pytest.mark.mpi
+def test_metadata_distributed_var_correct():
+    input_dict = {
+        "x_old": {
+            "tags": ["step_input_var", "x"],
+            "shape": 10 + MPI.COMM_WORLD.rank,
+            "distributed": True,
+        },
+        "x_acc_stages": {
+            "tags": ["accumulated_stage_var", "x"],
+            "shape": 10 + MPI.COMM_WORLD.rank,
+            "distributed": True,
+        },
+    }
+    output_dict = {
+        "x_update": {
+            "tags": ["stage_output_var", "x"],
+            "shape": 10 + MPI.COMM_WORLD.rank,
+            "distributed": True,
+        },
+    }
+    indep = om.IndepVarComp()
+    indep.add_output("x_old", shape_by_conn=True, distributed=True)
+    indep.add_output("x_acc_stages", shape_by_conn=True, distributed=True)
+    test_comp = MetadataTestComponent(input_dict=input_dict, output_dict=output_dict)
+    prob = om.Problem()
+    prob.model.add_subsystem("indep", indep, promotes=["*"])
+    prob.model.add_subsystem("test_comp", test_comp, promotes=["*"])
+    prob.setup()
+
+    array_size, translation_metadata, quantity_metadata = (
+        extract_time_integration_metadata(prob, ["x"])
+    )
+    add_distributivity_information(prob, quantity_metadata)
+
+    assert array_size == 10 + MPI.COMM_WORLD.rank
+    assert translation_metadata == {
+        "x": {
+            "step_input_var": "test_comp.x_old",
+            "accumulated_stage_var": "test_comp.x_acc_stages",
+            "stage_output_var": "test_comp.x_update",
+            "postproc_input_var": None,
+        }
+    }
+    assert quantity_metadata == {
+        "x": {
+            "type": "time_integration",
+            "shape": (10 + MPI.COMM_WORLD.rank,),
+            "global_shape": (21,),
+            "local": True,
+            "distributed": True,
+            "start_index": 0,
+            "end_index": 10 + MPI.COMM_WORLD.rank,
+            "functionally_integrated": False,
+            "functional_start_index": 0,
+            "functional_end_index": 0,
+            "global_start_index": 0 if MPI.COMM_WORLD.rank == 0 else 10,
+            "global_end_index": 10 if MPI.COMM_WORLD.rank == 0 else 21,
+        }
+    }
+
+
+@pytest.mark.mpi
+def test_metadata_parallel_group_correct():
+    input_dict_1 = {
+        "x_old": {
+            "tags": ["step_input_var", "x"],
+            "shape": (2, 3),
+            "distributed": False,
+        },
+        "x_acc_stages": {
+            "tags": ["accumulated_stage_var", "x"],
+            "shape": (2, 3),
+            "distributed": False,
+        },
+    }
+    output_dict_1 = {
+        "x_update": {
+            "tags": ["stage_output_var", "x"],
+            "shape": (2, 3),
+            "distributed": False,
+        },
+    }
+    input_dict_2 = {
+        "y_old": {
+            "tags": ["step_input_var", "y"],
+            "shape": (3, 2),
+            "distributed": False,
+        },
+        "y_acc_stages": {
+            "tags": ["accumulated_stage_var", "y"],
+            "shape": (3, 2),
+            "distributed": False,
+        },
+    }
+    output_dict_2 = {
+        "y_update": {
+            "tags": ["stage_output_var", "y"],
+            "shape": (3, 2),
+            "distributed": False,
+        },
+    }
+    par_group = om.ParallelGroup()
+    par_group.add_subsystem(
+        "test_comp_1",
+        MetadataTestComponent(input_dict=input_dict_1, output_dict=output_dict_1),
+        promotes=["*"],
+    )
+    par_group.add_subsystem(
+        "test_comp_2",
+        MetadataTestComponent(input_dict=input_dict_2, output_dict=output_dict_2),
+        promotes=["*"],
+    )
+    prob = om.Problem()
+    prob.model.add_subsystem("par_group", par_group, promotes=["*"])
+    prob.setup()
+
+    array_size, translation_metadata, quantity_metadata = (
+        extract_time_integration_metadata(prob, ["x", "y"])
+    )
+    add_distributivity_information(prob, quantity_metadata)
+
+    assert array_size == 6
+    if prob.comm.rank == 0:
+        assert translation_metadata == {
+            "x": {
+                "step_input_var": "par_group.test_comp_1.x_old",
+                "accumulated_stage_var": "par_group.test_comp_1.x_acc_stages",
+                "stage_output_var": "par_group.test_comp_1.x_update",
+                "postproc_input_var": None,
+            },
+            "y": {
+                "step_input_var": None,
+                "accumulated_stage_var": None,
+                "stage_output_var": None,
+                "postproc_input_var": None,
+            },
+        }
+        assert quantity_metadata == {
+            "x": {
+                "type": "time_integration",
+                "shape": (2, 3),
+                "global_shape": (2, 3),
+                "local": True,
+                "distributed": True,
+                "start_index": 0,
+                "end_index": 6,
+                "functionally_integrated": False,
+                "functional_start_index": 0,
+                "functional_end_index": 0,
+                "global_start_index": 0,
+                "global_end_index": 6,
+            },
+            "y": {
+                "type": "time_integration",
+                "shape": 0,
+                "global_shape": 0,
+                "local": False,
+                "distributed": True,
+                "start_index": 0,
+                "end_index": 0,
+                "functionally_integrated": False,
+                "functional_start_index": 0,
+                "functional_end_index": 0,
+                "global_start_index": 0,
+                "global_end_index": 0,
+            },
+        }
+    else:
+        assert translation_metadata == {
+            "x": {
+                "step_input_var": None,
+                "accumulated_stage_var": None,
+                "stage_output_var": None,
+                "postproc_input_var": None,
+            },
+            "y": {
+                "step_input_var": "par_group.test_comp_2.y_old",
+                "accumulated_stage_var": "par_group.test_comp_2.y_acc_stages",
+                "stage_output_var": "par_group.test_comp_2.y_update",
+                "postproc_input_var": None,
+            },
+        }
+        assert quantity_metadata == {
+            "x": {
+                "type": "time_integration",
+                "shape": 0,
+                "global_shape": 0,
+                "local": False,
+                "distributed": True,
+                "start_index": 0,
+                "end_index": 0,
+                "functionally_integrated": False,
+                "functional_start_index": 0,
+                "functional_end_index": 0,
+                "global_start_index": 0,
+                "global_end_index": 0,
+            },
+            "y": {
+                "type": "time_integration",
+                "shape": (3, 2),
+                "global_shape": (3, 2),
+                "local": True,
+                "distributed": True,
+                "start_index": 0,
+                "end_index": 6,
+                "functionally_integrated": False,
+                "functional_start_index": 0,
+                "functional_end_index": 0,
+                "global_start_index": 0,
+                "global_end_index": 6,
+            },
+        }

--- a/tests/parallel_group_test.py
+++ b/tests/parallel_group_test.py
@@ -547,16 +547,18 @@ def setup_time_integration_problem(
     if postprocessing_quantities is None:
         postprocessing_quantities = []
     time_integration_prob = om.Problem()
+    time_integration_indep = om.IndepVarComp()
+    time_integration_indep.add_output("b_initial", shape_by_conn=True, distributed=True)
+    time_integration_indep.add_output("c_initial", shape_by_conn=True, distributed=True)
+    time_integration_prob.model.add_subsystem(
+        "indep", time_integration_indep, promotes=["*"]
+    )
     time_integration_prob.model.add_subsystem(
         "rk_integrator",
         RungeKuttaIntegrator(
             time_stage_problem=stage_prob,
             postprocessing_problem=postproc_problem,
-            time_integration_quantities=[
-                "a",
-                "b" if stage_prob.comm.rank == 1 else "c",
-                "d",
-            ],
+            time_integration_quantities=["a", "b", "c", "d"],
             postprocessing_quantities=postprocessing_quantities,
             integration_control=integration_control,
             butcher_tableau=butcher_tableau,
@@ -568,6 +570,19 @@ def setup_time_integration_problem(
     time_integration_prob.model.linear_solver = om.LinearBlockGS()
     time_integration_prob.setup(mode=test_direction)
     return time_integration_prob
+
+
+def set_time_integration_initial_values(
+    time_integration_prob: om.Problem, initial_values: list
+):
+    time_integration_prob["d_initial"] = np.array([initial_values[0]])
+    if time_integration_prob.comm.rank == 0:
+        time_integration_prob["b_initial"] = np.zeros(0)
+        time_integration_prob["c_initial"] = np.array([initial_values[1]])
+    else:
+        time_integration_prob["b_initial"] = np.array([initial_values[2]])
+        time_integration_prob["c_initial"] = np.zeros(0)
+    time_integration_prob["a_initial"] = np.array([initial_values[3]])
 
 
 @pytest.mark.mpi
@@ -591,20 +606,16 @@ def test_parallel_group_time_integration(
         integration_control,
         butcher_tableau,
     )
-    time_integration_prob["d_initial"] = initial_values[0]
-    if time_integration_prob.comm.rank == 0:
-        time_integration_prob["c_initial"] = initial_values[1]
-    else:
-        time_integration_prob["b_initial"] = initial_values[2]
-    time_integration_prob["a_initial"] = initial_values[3]
+    set_time_integration_initial_values(time_integration_prob, initial_values)
     time_integration_prob.run_model()
 
     result_array = np.array(
         [
             time_integration_prob["d_final"][:],
-            time_integration_prob[
-                "c_final" if time_integration_prob.comm.rank == 0 else "b_final"
-            ][:],
+            time_integration_prob.get_val(
+                "c_final" if time_integration_prob.comm.rank == 0 else "b_final",
+                get_remote=False,
+            )[:],
             time_integration_prob["a_final"][:],
         ]
     ).flatten()
@@ -640,12 +651,7 @@ def test_parallel_group_time_integration_with_postprocessing(
         postproc_problem=postproc_prob,
         postprocessing_quantities=["sum"],
     )
-    time_integration_prob["d_initial"] = initial_values[0]
-    if time_integration_prob.comm.rank == 0:
-        time_integration_prob["c_initial"] = initial_values[1]
-    else:
-        time_integration_prob["b_initial"] = initial_values[2]
-    time_integration_prob["a_initial"] = initial_values[3]
+    set_time_integration_initial_values(time_integration_prob, initial_values)
     time_integration_prob.run_model()
 
     analytical_result = ode_system_solution(
@@ -715,7 +721,6 @@ def test_parallel_group_time_integration_totals(
     assert_check_totals(data)
 
 
-# currently not working, although not sure why
 @pytest.mark.mpi
 @pytest.mark.parametrize("num_steps", [1, 10])
 @pytest.mark.parametrize(

--- a/tests/parallel_group_test.py
+++ b/tests/parallel_group_test.py
@@ -574,7 +574,8 @@ def setup_time_integration_problem(
 
 def set_time_integration_initial_values(
     time_integration_prob: om.Problem, initial_values: list
-):
+) -> None:
+    """Convenience function for setting the inputs if the time integration."""
     time_integration_prob["d_initial"] = np.array([initial_values[0]])
     if time_integration_prob.comm.rank == 0:
         time_integration_prob["b_initial"] = np.zeros(0)

--- a/tests/test_functional_coefficients.py
+++ b/tests/test_functional_coefficients.py
@@ -1,6 +1,6 @@
 """FunctionalCoefficients that are useful for tests, but not for real usage."""
 
-from typing import List, Union
+from __future__ import annotations
 
 import numpy as np
 
@@ -16,12 +16,10 @@ class FifthStepOfQuantity(FunctionalCoefficients):
     def __init__(self, quantity: str):
         self._quantity_list = [quantity]
 
-    def list_quantities(self) -> List[str]:
+    def list_quantities(self) -> list[str]:
         return self._quantity_list
 
-    def get_coefficient(
-        self, time_step: int, quantity: str
-    ) -> Union[float, np.ndarray]:
+    def get_coefficient(self, time_step: int, quantity: str) -> float | np.ndarray:
         if quantity == self._quantity_list[0] and time_step == 5:
             return 1.0
         else:

--- a/tests/test_runge_kutta_scheme.py
+++ b/tests/test_runge_kutta_scheme.py
@@ -1,6 +1,7 @@
 """Tests for the Runge-Kutta integration core."""
 
-from typing import Callable, Tuple
+from __future__ import annotations
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -26,7 +27,7 @@ class RkFunctionProvider:
             [np.ndarray, np.ndarray, float, float, float], np.ndarray
         ],
         stage_computation_functor_transposed_jacvec: Callable[
-            [np.ndarray, float, float, float], Tuple[np.ndarray, np.ndarray]
+            [np.ndarray, float, float, float], tuple[np.ndarray, np.ndarray]
         ],
     ):
         self.stage_computation_functor = stage_computation_functor
@@ -461,7 +462,7 @@ def test_compute_stage_jacvec(
         old_time,
         old_state_perturbation,
         accumulated_stages_perturbation,
-        **linearization_args
+        **linearization_args,
     ) == pytest.approx(expected_jacvec_product)
 
 
@@ -526,7 +527,7 @@ def test_compute_stage_transposed_jacvec(
     old_time: float,
     joined_perturbation: np.ndarray,
     linearization_args: dict,
-    expected_jacvec_product: Tuple[np.ndarray, np.ndarray],
+    expected_jacvec_product: tuple[np.ndarray, np.ndarray],
 ):
     """Tests the compute_stage_tranposed_jacvec function."""
     assert rk_scheme.compute_stage_transposed_jacvec(


### PR DESCRIPTION
The collection of metadata from the inner OpenMDAO problems was rather unorganized. This takes this out of the `RungeKuttaIntegrator` and also updates it to close #7 . This should also make it easier to add additional metadata in the future, e.g. when passing through time-independent inputs from the inner problems, or when dealing with algrebraic variables for differential-algebraic equations.