### PR TITLE
Revamp file writing

### DIFF
--- a/src/rkopenmdao/file_writer.py
+++ b/src/rkopenmdao/file_writer.py
@@ -1,0 +1,93 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from itertools import chain
+
+import h5py
+from mpi4py.MPI import Comm
+import numpy as np
+
+from .metadata_extractor import TimeIntegrationMetadata
+
+
+@dataclass
+class FileWriterInterface(ABC):
+    """Interface for general file writers in RKOpenMDAO."""
+
+    file_name: str
+    time_integration_metadata: TimeIntegrationMetadata
+    comm: Comm
+
+    @abstractmethod
+    def setup_file(self):
+        """Creates file and prepares other necessary one-time work."""
+
+    @abstractmethod
+    def write_step(
+        self,
+        step: int,
+        time: float,
+        time_integration_data: np.ndarray,
+        postprocessing_data: np.ndarray,
+    ):
+        """Writes out step to file"""
+
+
+@dataclass
+class Hdf5FileWriter(FileWriterInterface):
+
+    def setup_file(self):
+        if self.comm.rank == 0:
+            written_out_quantities = chain(
+                self.time_integration_metadata.time_integration_quantity_list,
+                self.time_integration_metadata.postprocessing_quantity_list,
+            )
+            with h5py.File(self.file_name, mode="w") as f:
+                for quantity in written_out_quantities:
+                    f.create_group(quantity.name)
+
+    def write_step(
+        self,
+        step: int,
+        time: float,
+        time_integration_data: np.ndarray,
+        postprocessing_data: np.ndarray,
+    ):
+        written_out_quantities = chain(
+            self.time_integration_metadata.time_integration_quantity_list,
+            self.time_integration_metadata.postprocessing_quantity_list,
+        )
+        with h5py.File(self.file_name, mode="r+", driver="mpio", comm=self.comm) as f:
+            for quantity in written_out_quantities:
+                quantity_group = f[quantity.name]
+                dataset = quantity_group.create_dataset(
+                    str(step),
+                    shape=quantity.array_metadata.global_shape,
+                    dtype=np.float64,
+                )
+                dataset.attrs["time"] = time
+                if quantity.array_metadata.local:
+                    start_array = quantity.array_metadata.start_index
+                    end_array = quantity.array_metadata.end_index
+                    start_tuple = np.unravel_index(
+                        quantity.array_metadata.global_start_index,
+                        quantity.array_metadata.global_shape,
+                    )
+                    end_tuple = np.unravel_index(
+                        quantity.array_metadata.global_end_index - 1,
+                        quantity.array_metadata.global_shape,
+                    )
+                    access_list = []
+                    for start_index, end_index in zip(start_tuple, end_tuple):
+                        access_list.append(slice(start_index, end_index + 1))
+                    if quantity.type == "time_integration":
+                        f[quantity.name][str(step)][tuple(access_list)] = (
+                            time_integration_data[start_array:end_array].reshape(
+                                quantity.array_metadata.shape
+                            )
+                        )
+                    elif quantity.type == "postprocessing":
+                        f[quantity.name][str(step)][tuple(access_list)] = (
+                            postprocessing_data[start_array:end_array].reshape(
+                                quantity.array_metadata.shape
+                            )
+                        )

--- a/src/rkopenmdao/metadata_extractor.py
+++ b/src/rkopenmdao/metadata_extractor.py
@@ -125,7 +125,7 @@ def extract_time_integration_metadata(
     )
     global_quantities = stage_problem.model.get_io_metadata(
         iotypes="output",
-        metadata_keys=["tags"],
+        metadata_keys=["tags", "global_shape"],
         tags=time_integration_quantity_list,
         get_remote=True,
     )
@@ -154,7 +154,7 @@ def extract_time_integration_metadata(
             quantity = TimeIntegrationQuantity(
                 type="time_integration",
                 name=quantity_name,
-                array_metadata=ArrayMetadata(),
+                array_metadata=ArrayMetadata(global_shape=data["global_shape"]),
                 translation_metadata=TimeIntegrationTranslationMetadata(),
             )
         quantity_list.append(quantity)
@@ -291,7 +291,7 @@ def add_time_independent_input_metadata(
     )
     global_quantities = stage_problem.model.get_io_metadata(
         iotypes="input",
-        metadata_keys=["tags"],
+        metadata_keys=["tags", "global_shape"],
         tags=time_independent_input_quantity_list,
         get_remote=True,
     )
@@ -322,7 +322,7 @@ def add_time_independent_input_metadata(
             quantity = TimeIndependentQuantity(
                 type="independent_input",
                 name=quantity_name,
-                array_metadata=ArrayMetadata(),
+                array_metadata=ArrayMetadata(global_shape=data["global_shape"]),
                 translation_metadata=TimeIndependentInputTranslationMetadata(),
             )
         runge_kutta_metadata.time_independent_input_quantity_list.append(quantity)
@@ -427,7 +427,7 @@ def add_postprocessing_metadata(
     )
     global_postproc_quantities = postproc_problem.model.get_io_metadata(
         iotypes="output",
-        metadata_keys=["tags"],
+        metadata_keys=["tags", "global_shape"],
         tags=postprocessing_quantity_list,
         get_remote=True,
     )
@@ -454,7 +454,7 @@ def add_postprocessing_metadata(
             quantity = PostprocessingQuantity(
                 type="postprocessing",
                 name=quantity_name,
-                array_metadata=ArrayMetadata(),
+                array_metadata=ArrayMetadata(global_shape=data["global_shape"]),
                 translation_metadata=PostprocessingTranslationMetadata(),
             )
         runge_kutta_metadata.postprocessing_quantity_list.append(quantity)

--- a/src/rkopenmdao/runge_kutta_integrator.py
+++ b/src/rkopenmdao/runge_kutta_integrator.py
@@ -35,6 +35,8 @@ from .metadata_extractor import (
     TimeIntegrationMetadata,
 )
 
+from .file_writer import FileWriterInterface, Hdf5FileWriter
+
 
 class RungeKuttaIntegrator(om.ExplicitComponent):
     """Outer component for solving time-dependent problems with explicit or diagonally
@@ -77,6 +79,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
     _cached_input: tuple[np.ndarray, np.ndarray]
 
     _disable_write_out: bool
+    _file_writer: FileWriterInterface | None
 
     _checkpointer: CheckpointInterface | None
 
@@ -110,7 +113,9 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
         self._time_integration_metadata = None
 
         self._cached_input = (np.full(0, np.nan), np.full(0, np.nan))
+
         self._disable_write_out = False
+        self._file_writer = None
 
         self._checkpointer = None
 
@@ -164,6 +169,12 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
             diagonal element of the butcher tableau, or the current time step and stage,
             which then can be read by anyone else holding the same instance (like e.g.
             components in the time_stage_problem).""",
+        )
+        self.options.declare(
+            "file_writing_implementation",
+            default=Hdf5FileWriter,
+            check_valid=self.check_file_writer_type,
+            desc="Defines what kind of file writing should be used.",
         )
 
         self.options.declare(
@@ -272,6 +283,15 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
         # OpenMDAO needs that specific interface, even if we don't need it fully.
         if not issubclass(value, CheckpointInterface):
             raise TypeError(f"{value} is not a subclass of CheckpointInterface")
+
+    @staticmethod
+    def check_file_writer_type(name, value):
+        """Checks whether the passed file writing type for the options is an actual
+        subclass of FileWriterInterface"""
+        # pylint: disable=unused-argument
+        # OpenMDAO needs that specific interface, even if we don't need it fully.
+        if not issubclass(value, FileWriterInterface):
+            raise TypeError(f"{value} is not a subclass of FileWriterInterface")
 
     def setup(self):
         self._setup_inner_problems()
@@ -519,51 +539,14 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
 
     def _configure_write_out(self):
         self._disable_write_out = self.options["write_out_distance"] == 0
+        if not self._disable_write_out:
+            self._file_writer = self.options["file_writing_implementation"](
+                self.options["write_file"], self._time_integration_metadata, self.comm
+            )
 
     def _setup_write_file(self):
-        if not self._disable_write_out:
-            delta_t = self.options["integration_control"].delta_t
-            initial_time = self.options["integration_control"].initial_time
-            num_steps = self.options["integration_control"].num_steps
-            written_out_quantities = chain(
-                self._time_integration_metadata.time_integration_quantity_list,
-                self._time_integration_metadata.postprocessing_quantity_list,
-            )
-            for i in range(self.comm.size):
-                if i == self.comm.rank:
-                    with h5py.File(
-                        self.options["write_file"], mode="w" if i == 0 else "r+"
-                    ) as f:
-                        for quantity in written_out_quantities:
-                            for j in range(
-                                0,
-                                num_steps,
-                                self.options["write_out_distance"],
-                            ):
-                                # check whether dataset was already created by other
-                                # process
-                                path = quantity.name + "/" + str(j)
-                                if path not in f:
-                                    dataset = f.create_dataset(
-                                        path,
-                                        data=np.full(
-                                            quantity.array_metadata.global_shape, np.nan
-                                        ),
-                                    )
-                                    dataset.attrs["time"] = j * delta_t + initial_time
-                            path = quantity.name + "/" + str(num_steps)
-                            if path not in f:
-                                dataset = f.create_dataset(
-                                    path,
-                                    data=np.full(
-                                        quantity.array_metadata.global_shape, np.nan
-                                    ),
-                                )
-                                dataset.attrs["time"] = (
-                                    num_steps * delta_t + initial_time
-                                )
-                if self.comm.size > 1:
-                    self.comm.Barrier()
+        if self._file_writer is not None:
+            self._file_writer.setup_file()
 
     def _setup_checkpointing(self):
         self._checkpointer = self.options["checkpointing_type"](
@@ -638,6 +621,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
             print(self.comm.rank, "-----------------------------------------------")
             self._write_out(
                 0,
+                self.options["integration_control"].initial_time,
                 self._serialized_state,
                 self._postprocessing_state,
                 open_mode="r+",
@@ -646,56 +630,15 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
     def _write_out(
         self,
         step: int,
+        time: float,
         serialized_state: np.ndarray,
         postprocessing_state=None,
         open_mode="r+",
     ):
-        further_args = {}
-        if self.comm.size > 1:
-            further_args["driver"] = "mpio"
-            further_args["comm"] = self.comm
-        with h5py.File(self.options["write_file"], mode=open_mode, **further_args) as f:
-            if self.comm.size > 1:
-                f.atomic = True
-            for quantity in chain(
-                self._time_integration_metadata.time_integration_quantity_list,
-                self._time_integration_metadata.postprocessing_quantity_list,
-            ):
-                start = quantity.array_metadata.start_index
-                end = quantity.array_metadata.end_index
-                # check whether data has already been written on dataset by checking
-                # first element
-                if np.isnan(
-                    f[quantity.name][str(step)][
-                        np.unravel_index(
-                            quantity.array_metadata.global_start_index,
-                            quantity.array_metadata.global_shape,
-                        )
-                    ]
-                ):
-                    start_tuple = np.unravel_index(
-                        quantity.array_metadata.global_start_index,
-                        quantity.array_metadata.global_shape,
-                    )
-                    end_tuple = np.unravel_index(
-                        quantity.array_metadata.global_end_index - 1,
-                        quantity.array_metadata.global_shape,
-                    )
-                    access_list = []
-                    for start_index, end_index in zip(start_tuple, end_tuple):
-                        access_list.append(slice(start_index, end_index + 1))
-                    if quantity.type == "time_integration":
-                        f[quantity.name][str(step)][tuple(access_list)] = (
-                            serialized_state[start:end].reshape(
-                                quantity.array_metadata.shape
-                            )
-                        )
-                    elif quantity.type == "postprocessing":
-                        f[quantity.name][str(step)][tuple(access_list)] = (
-                            postprocessing_state[start:end].reshape(
-                                quantity.array_metadata.shape
-                            )
-                        )
+        if self._file_writer is not None:
+            self._file_writer.write_step(
+                step, time, serialized_state, postprocessing_state
+            )
 
     def _compute_functional_phase(self):
         if self._functional_quantities:
@@ -894,12 +837,14 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
 
     def _run_step_write_out_phase(self):
         step = self.options["integration_control"].step
+        time = self.options["integration_control"].step_time_new
         if not self._disable_write_out and (
             step % self.options["write_out_distance"] == 0
             or step == self.options["integration_control"].num_steps
         ):
             self._write_out(
                 step,
+                time,
                 self._serialized_state,
                 self._postprocessing_state,
                 open_mode="r+",

--- a/tests/metadata_extractor_test.py
+++ b/tests/metadata_extractor_test.py
@@ -845,7 +845,7 @@ def test_metadata_parallel_group_correct():
             TimeIntegrationQuantity(
                 "y",
                 "time_integration",
-                ArrayMetadata(distributed=True),
+                ArrayMetadata(global_shape=(3, 2), distributed=True),
                 TimeIntegrationTranslationMetadata(),
             ),
         ]
@@ -854,7 +854,7 @@ def test_metadata_parallel_group_correct():
             TimeIntegrationQuantity(
                 "x",
                 "time_integration",
-                ArrayMetadata(distributed=True),
+                ArrayMetadata(global_shape=(2, 3), distributed=True),
                 TimeIntegrationTranslationMetadata(),
             ),
             TimeIntegrationQuantity(

--- a/tests/write_file_test.py
+++ b/tests/write_file_test.py
@@ -51,7 +51,7 @@ def test_monodisciplinary(write_out_distance, write_file):
         for i in range(1, write_out_distance):
             assert str(i) not in f["x"].keys()
         assert str(100) in f["x"].keys()
-        assert time_int_prob["rk_integration.x_final"] == f["x"][str(100)]
+        assert time_int_prob["rk_integration.x_final"] == f["x"][str(100)][:]
 
 
 @pytest.mark.rk


### PR DESCRIPTION
The existing h5py file writer was changed: Instead of creating datasets for all future requested steps at the start of the time integration, they  now only get created right before they are needed and written to.

Also introduced an interface for file writers to have an option to easily add new ones that e.g. are not based on hdf5.