### PR TITLE
Fixing PETsC installation in CI-pipeline

### DIFF
--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -20,10 +20,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev
-    - name: Set up Python 3.9
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.8"
         cache: "pip"
         cache-dependency-path: setup.py
     - name: Install dependencies

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -29,6 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install cython  # required to build petsc4py
+        export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py
         CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Install OS Packages
       run: |
         sudo apt-get update
-        sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev
+        sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libopenblas64-dev
     - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install cython  # required to build petsc4py
-        pip install --with-blas-lib= petsc
+        pip install petsc
         pip install petsc4py
         CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
         pip install ".[dev]"

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -19,17 +19,17 @@ jobs:
     - name: Install OS Packages
       run: |
         sudo apt-get update
-        sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libopenblas64-dev
-    - name: Set up Python 3.8
+        sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.9"
         cache: "pip"
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
         pip install cython  # required to build petsc4py
-        pip install petsc
+        pip install --with-blas-lib= petsc
         pip install petsc4py
         CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
         pip install ".[dev]"


### PR DESCRIPTION
The CI pipeline uses the latest version of ubuntu. Ever since that version changed from jammy (22.04)  to noble (24.04), the pipeline fails at the installation of PETsC via pip (see #15). The aim of this pull request is to fix this issue.