### PR TITLE
Optimization example for the Van der Pol Oscillator and small changes to file writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ convergence_test/**
 **/tests/dat_**
 **.dat
 .coverage
+file_0

--- a/examples/van_der_pol_oscillator/van_der_pol_oscillator_computation.py
+++ b/examples/van_der_pol_oscillator/van_der_pol_oscillator_computation.py
@@ -1,0 +1,430 @@
+r"""
+Optimization example using RKOpenMDAO on the Van Der Pol oscillator:
+https://en.wikipedia.org/wiki/Van_der_Pol_oscillator
+The form used is the system of first order ODEs
+y_1' = y_2,
+y_2' = ε * (1 - y_1**2)*y_2 - y_1.
+
+The functional to be minimized is
+J = ∫_0^t_end (y_1(s)**2 + y_2(s)**2 - 1) * tanh(y_1(s)**2 + y_2(s)**2 - 1) ds.
+This uses
+a) the equation for the circle in its squared form: 1 = y_1(s)**2 + y_2(s)**2,
+b) a continuous approximation for the absolute value: |x| ≈ x * tanh(x).
+
+Combining this means that the functional measures the absolute distance between the
+trajectory of the ODE system and a unit circle. The optimum would be achieved with
+ε ≡ 0 with initial values for the ODE system on the unit circle.
+
+This script offers three arguments:
+--epsilon_mode with allowed values "one_for_all" and "per step".
+    The "one_for_all"-option defines ε to be a constant over the whole time
+    integration, which is then optimized to minimize the above functional.
+    The "per_step"-option on the other hand allows ε to vary over time, meaning
+    there can be different values of ε per step. Again, all these different values
+    are varied to minimize the above functional.
+--y1_optimization: If this option is passed, the initial value of y_1 is part of the
+    values varied to achieve the optimum of J.
+--y2_optimization: If this option is passed, the initial value of y_2 is part of the
+    values varied to achieve the optimum of J.
+"""
+
+import argparse
+
+import numpy as np
+import openmdao.api as om
+
+from rkopenmdao.butcher_tableaux import third_order_four_stage_esdirk
+from rkopenmdao.integration_control import IntegrationControl
+from rkopenmdao.runge_kutta_integrator import RungeKuttaIntegrator
+from rkopenmdao.checkpoint_interface.pyrevolve_checkpointer import PyrevolveCheckpointer
+
+
+class VanDerPolComponent1(om.ImplicitComponent):
+    def initialize(self):
+        self.options.declare("integration_control", types=IntegrationControl)
+
+    def setup(self):
+        self.add_input("y2", val=0.0)
+        self.add_input("y1_old", val=2.0, tags=["y1", "step_input_var"])
+        self.add_input("y1s_i", val=0.0, tags=["y1", "accumulated_stage_var"])
+        self.add_output("y1_update", val=0.0, tags=["y1", "stage_output_var"])
+        self.add_output("y1", val=2.0)
+
+    def apply_nonlinear(self, inputs, outputs, residuals):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        residuals["y1_update"] = outputs["y1_update"] - inputs["y2"]
+        residuals["y1"] = (
+            outputs["y1"]
+            - inputs["y1_old"]
+            - delta_t * inputs["y1s_i"]
+            - delta_t * butcher_diagonal_element * outputs["y1_update"]
+        )
+
+    def solve_nonlinear(self, inputs, outputs):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        outputs["y1_update"] = inputs["y2"]
+        outputs["y1"] = (
+            inputs["y1_old"]
+            + delta_t * inputs["y1s_i"]
+            + delta_t * butcher_diagonal_element * outputs["y1_update"]
+        )
+
+    def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        if mode == "fwd":
+            if "y1_update" in d_residuals:
+                if "y1_update" in d_outputs:
+                    d_residuals["y1_update"] += d_outputs["y1_update"]
+                if "y2" in d_inputs:
+                    d_residuals["y1_update"] -= d_inputs["y2"]
+            if "y1" in d_residuals:
+                if "y1" in d_outputs:
+                    d_residuals["y1"] += d_outputs["y1"]
+                if "y1_old" in d_inputs:
+                    d_residuals["y1"] -= d_inputs["y1_old"]
+                if "y1s_i" in d_inputs:
+                    d_residuals["y1"] -= delta_t * d_inputs["y1s_i"]
+                if "y1_update" in d_outputs:
+                    d_residuals["y1"] -= (
+                        butcher_diagonal_element * delta_t * d_outputs["y1_update"]
+                    )
+        elif mode == "rev":
+            if "y1_update" in d_residuals:
+                if "y1_update" in d_outputs:
+                    d_outputs["y1_update"] += d_residuals["y1_update"]
+                if "y2" in d_inputs:
+                    d_inputs["y2"] -= d_residuals["y1_update"]
+            if "y1" in d_residuals:
+                if "y1" in d_outputs:
+                    d_outputs["y1"] += d_residuals["y1"]
+                if "y1_old" in d_inputs:
+                    d_inputs["y1_old"] -= d_residuals["y1"]
+                if "y1s_i" in d_inputs:
+                    d_inputs["y1s_i"] -= delta_t * d_residuals["y1"]
+                if "y1_update" in d_outputs:
+                    d_outputs["y1_update"] -= (
+                        butcher_diagonal_element * delta_t * d_residuals["y1"]
+                    )
+
+    def solve_linear(self, d_outputs, d_residuals, mode):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        if mode == "fwd":
+            d_outputs["y1_update"] = d_residuals["y1_update"]
+            d_outputs["y1"] = (
+                d_residuals["y1"]
+                + delta_t * butcher_diagonal_element * d_residuals["y1_update"]
+            )
+        elif mode == "rev":
+            d_residuals["y1_update"] = (
+                d_outputs["y1_update"]
+                + delta_t * butcher_diagonal_element * d_outputs["y1"]
+            )
+            d_residuals["y1"] = d_outputs["y1"]
+
+
+class VanDerPolComponent2(om.ImplicitComponent):
+    def initialize(self):
+        self.options.declare("integration_control", types=IntegrationControl)
+        self.options.declare("epsilon_mode", values=["one_for_all", "per_step"])
+
+    def setup(self):
+        if self.options["epsilon_mode"] == "one_for_all":
+            self.add_input(
+                "epsilon", val=1.0, tags=["epsilon", "time_independent_input_var"]
+            )
+        else:
+            self.add_input(
+                "epsilon",
+                val=np.ones(self.options["integration_control"].num_steps),
+                tags=["epsilon", "time_independent_input_var"],
+            )
+        self.add_input("y1", val=0.0)
+        self.add_input("y2_old", val=-2.0 / 3.0, tags=["y2", "step_input_var"])
+        self.add_input("y2s_i", val=0.0, tags=["y2", "accumulated_stage_var"])
+        self.add_output("y2_update", val=0.0, tags=["y2", "stage_output_var"])
+        self.add_output("y2", val=-2.0 / 3.0)
+
+    def apply_nonlinear(self, inputs, outputs, residuals):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        epsilon = (
+            inputs["epsilon"]
+            if self.options["epsilon_mode"] == "one_for_all"
+            else inputs["epsilon"][self.options["integration_control"].step - 1]
+        )
+        residuals["y2_update"] = (
+            outputs["y2_update"]
+            - epsilon * (1 - inputs["y1"] ** 2) * outputs["y2"]
+            + inputs["y1"]
+        )
+        residuals["y2"] = (
+            outputs["y2"]
+            - inputs["y2_old"]
+            - delta_t * inputs["y2s_i"]
+            - delta_t * butcher_diagonal_element * outputs["y2_update"]
+        )
+
+    def solve_nonlinear(self, inputs, outputs):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        epsilon = (
+            inputs["epsilon"]
+            if self.options["epsilon_mode"] == "one_for_all"
+            else inputs["epsilon"][self.options["integration_control"].step - 1]
+        )
+        divisor = (epsilon - inputs["y1"] ** 2) * delta_t * butcher_diagonal_element - 1
+        outputs["y2_update"] = (
+            inputs["y1"]
+            - epsilon
+            * (1 - inputs["y1"] ** 2)
+            * (inputs["y2_old"] + delta_t * inputs["y2s_i"])
+        ) / divisor
+
+        outputs["y2"] = (
+            inputs["y2_old"]
+            + delta_t * inputs["y2s_i"]
+            + delta_t * butcher_diagonal_element * outputs["y2_update"]
+        )
+
+    def linearize(self, inputs, outputs, *_args):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        epsilon = (
+            inputs["epsilon"]
+            if self.options["epsilon_mode"] == "one_for_all"
+            else inputs["epsilon"][self.options["integration_control"].step - 1]
+        )
+        divisor = (
+            1 - epsilon * (1 - inputs["y1"] ** 2) * delta_t * butcher_diagonal_element
+        )
+        self.inv_jac = np.zeros((2, 2))
+        self.inv_jac[0, 0] = 1.0
+        self.inv_jac[0, 1] = epsilon * (1 - inputs["y1"][0] ** 2)
+        self.inv_jac[1, 0] = delta_t * butcher_diagonal_element
+        self.inv_jac[1, 1] = 1.0
+        self.inv_jac /= divisor
+
+    def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
+        delta_t = self.options["integration_control"].delta_t
+        butcher_diagonal_element = self.options[
+            "integration_control"
+        ].butcher_diagonal_element
+        epsilon = (
+            inputs["epsilon"]
+            if self.options["epsilon_mode"] == "one_for_all"
+            else inputs["epsilon"][self.options["integration_control"].step - 1]
+        )
+        if mode == "fwd":
+            if "y2_update" in d_residuals:
+                if "y2_update" in d_outputs:
+                    d_residuals["y2_update"] += d_outputs["y2_update"]
+                if "y1" in d_inputs:
+                    d_residuals["y2_update"] += (
+                        1 + 2 * inputs["y1"] * outputs["y2"] * epsilon
+                    ) * d_inputs["y1"]
+                if "y2" in d_outputs:
+                    d_residuals["y2_update"] -= (
+                        epsilon * (1 - inputs["y1"] ** 2) * d_outputs["y2"]
+                    )
+                if "epsilon" in d_inputs:
+                    d_residuals["y2_update"] -= (
+                        (1 - inputs["y1"] ** 2)
+                        * outputs["y2"]
+                        * (
+                            d_inputs["epsilon"]
+                            if self.options["epsilon_mode"] == "one_for_all"
+                            else d_inputs["epsilon"][
+                                self.options["integration_control"].step - 1
+                            ]
+                        )
+                    )
+            if "y2" in d_residuals:
+                if "y2" in d_outputs:
+                    d_residuals["y2"] += d_outputs["y2"]
+                if "y2_old" in d_inputs:
+                    d_residuals["y2"] -= d_inputs["y2_old"]
+                if "y2s_i" in d_inputs:
+                    d_residuals["y2"] -= delta_t * d_inputs["y2s_i"]
+                if "y2_update" in d_outputs:
+                    d_residuals["y2"] -= (
+                        butcher_diagonal_element * delta_t * d_outputs["y2_update"]
+                    )
+        elif mode == "rev":
+            if "y2_update" in d_residuals:
+                if "y2_update" in d_outputs:
+                    d_outputs["y2_update"] += d_residuals["y2_update"]
+                if "y1" in d_inputs:
+                    d_inputs["y1"] += (
+                        1 + 2 * inputs["y1"] * outputs["y2"] * epsilon
+                    ) * d_residuals["y2_update"]
+                if "y2" in d_outputs:
+                    d_outputs["y2"] -= (
+                        epsilon * (1 - inputs["y1"] ** 2) * d_residuals["y2_update"]
+                    )
+                if "epsilon" in d_inputs:
+                    if self.options["epsilon_mode"] == "one_for_all":
+                        d_inputs["epsilon"] -= (
+                            (1 - inputs["y1"] ** 2)
+                            * outputs["y2"]
+                            * d_residuals["y2_update"]
+                        )
+                    else:
+                        d_inputs["epsilon"][
+                            self.options["integration_control"].step - 1
+                        ] -= (
+                            (1 - inputs["y1"] ** 2)
+                            * outputs["y2"]
+                            * d_residuals["y2_update"]
+                        )
+            if "y2" in d_residuals:
+                if "y2" in d_outputs:
+                    d_outputs["y2"] += d_residuals["y2"]
+                if "y2_old" in d_inputs:
+                    d_inputs["y2_old"] -= d_residuals["y2"]
+                if "y2s_i" in d_inputs:
+                    d_inputs["y2s_i"] -= delta_t * d_residuals["y2"]
+                if "y2_update" in d_outputs:
+                    d_outputs["y2_update"] -= (
+                        butcher_diagonal_element * delta_t * d_residuals["y2"]
+                    )
+
+    def solve_linear(self, d_outputs, d_residuals, mode):
+        if mode == "fwd":
+            d_outputs["y2_update"] = (
+                self.inv_jac[0, 0] * d_residuals["y2_update"]
+                + self.inv_jac[0, 1] * d_residuals["y2"]
+            )
+            d_outputs["y2"] = (
+                self.inv_jac[1, 0] * d_residuals["y2_update"]
+                + self.inv_jac[1, 1] * d_residuals["y2"]
+            )
+        elif mode == "rev":
+            d_residuals["y2_update"] = (
+                self.inv_jac[0, 0] * d_outputs["y2_update"]
+                + self.inv_jac[1, 0] * d_outputs["y2"]
+            )
+            d_residuals["y2"] = (
+                self.inv_jac[0, 1] * d_outputs["y2_update"]
+                + self.inv_jac[1, 1] * d_outputs["y2"]
+            )
+
+
+class VanDerPolFunctional(om.ExplicitComponent):
+    def setup(self):
+        self.add_input("y1")
+        self.add_input("y2")
+        self.add_output("J", val=0.0, tags=["J", "stage_output_var"])
+
+    def compute(self, inputs, outputs, *args):
+
+        outputs["J"] = (inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1) * np.tanh(
+            inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1
+        )
+
+    def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode, *args):
+        tanh_value = np.tanh(inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1)
+        tanh_deriv = tanh_value + (inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1) * (
+            1 - tanh_value**2
+        )
+        if mode == "fwd":
+            if "J" in d_outputs:
+                if "y1" in d_inputs:
+                    d_outputs["J"] += 2 * tanh_deriv * inputs["y1"] * d_inputs["y1"]
+                if "y2" in d_inputs:
+                    d_outputs["J"] += 2 * tanh_deriv * inputs["y2"] * d_inputs["y2"]
+        elif mode == "rev":
+            if "J" in d_outputs:
+                if "y1" in d_inputs:
+                    d_inputs["y1"] += 2 * tanh_deriv * inputs["y1"] * d_outputs["J"]
+                if "y2" in d_inputs:
+                    d_inputs["y2"] += 2 * tanh_deriv * inputs["y2"] * d_outputs["J"]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--y1_optimization", action="store_true")
+    parser.add_argument("--y2_optimization", action="store_true")
+    parser.add_argument("--epsilon_mode", choices=["one_for_all", "per_step"])
+    parsed_args = parser.parse_args()
+
+    y1_optimization = parsed_args.y1_optimization
+    y2_optimization = parsed_args.y2_optimization
+    epsilon_mode = parsed_args.epsilon_mode
+
+    delta_t = 0.1
+    num_steps = 100
+    butcher_tableau = third_order_four_stage_esdirk
+    integration_control = IntegrationControl(0.0, num_steps, delta_t)
+    vdp_1 = VanDerPolComponent1(integration_control=integration_control)
+    vdp_2 = VanDerPolComponent2(
+        integration_control=integration_control, epsilon_mode=epsilon_mode
+    )
+    vdp_functional = VanDerPolFunctional()
+
+    vdp_inner_prob = om.Problem()
+    vdp_inner_prob.model.add_subsystem("vdp1", vdp_1, promotes=["*"])
+    vdp_inner_prob.model.add_subsystem("vdp2", vdp_2, promotes=["*"])
+    vdp_inner_prob.model.add_subsystem("vdp_functional", vdp_functional, promotes=["*"])
+
+    vdp_inner_prob.model.nonlinear_solver = om.NewtonSolver(
+        solve_subsystems=False, iprint=2, err_on_non_converge=True, maxiter=1000
+    )
+    vdp_inner_prob.model.linear_solver = om.ScipyKrylov(iprint=2)
+
+    # vdp_inner_prob.setup()
+    # vdp_inner_prob.run_model()
+    # vdp_inner_prob.check_partials(show_only_incorrect=True)
+    # quit()
+
+    vdp_rk_integrator = RungeKuttaIntegrator(
+        time_stage_problem=vdp_inner_prob,
+        time_integration_quantities=["y1", "y2", "J"],
+        butcher_tableau=butcher_tableau,
+        integration_control=integration_control,
+        time_independent_input_quantities=["epsilon"],
+        checkpointing_type=PyrevolveCheckpointer,
+        write_out_distance=1,
+        write_file="vdp.h5",
+    )
+
+    rk_prob = om.Problem()
+    rk_prob.model.add_subsystem("rk_integration", vdp_rk_integrator, promotes=["*"])
+    rk_prob.model.add_design_var("epsilon", lower=-10, upper=10)
+    if y1_optimization:
+        rk_prob.model.add_objective("y1_initial", lower=-3, upper=3)
+    if y2_optimization:
+        rk_prob.model.add_design_var("y2_initial", lower=-3, upper=3)
+    rk_prob.model.add_objective("J_final")
+    rk_prob.driver = om.ScipyOptimizeDriver(optimizer="SLSQP")
+
+    rk_prob.setup()
+    rk_prob["y1_initial"] = 2.0
+    rk_prob["y2_initial"] = 2.0
+    rk_prob["epsilon"] = (
+        0.38  # optimization goes wrong for initial eps >= 0.4, works for eps <= 0.39
+    )
+    # rk_prob.run_model()
+
+    rk_prob.run_driver()
+
+    print(rk_prob["y2_initial"])
+    print(rk_prob["epsilon"])
+    print(rk_prob["J_final"])

--- a/examples/van_der_pol_oscillator/van_der_pol_oscillator_computation.py
+++ b/examples/van_der_pol_oscillator/van_der_pol_oscillator_computation.py
@@ -13,19 +13,21 @@ b) a continuous approximation for the absolute value: |x| ≈ x * tanh(x).
 
 Combining this means that the functional measures the absolute distance between the
 trajectory of the ODE system and a unit circle. The optimum would be achieved with
-ε ≡ 0 with initial values for the ODE system on the unit circle.
+ε ≡ 0, assuming the initial values for the ODE system lie on the unit circle.
 
 This script offers three arguments:
---epsilon_mode with allowed values "one_for_all" and "per step".
-    The "one_for_all"-option defines ε to be a constant over the whole time
-    integration, which is then optimized to minimize the above functional.
-    The "per_step"-option on the other hand allows ε to vary over time, meaning
-    there can be different values of ε per step. Again, all these different values
-    are varied to minimize the above functional.
 --y1_optimization: If this option is passed, the initial value of y_1 is part of the
     values varied to achieve the optimum of J.
 --y2_optimization: If this option is passed, the initial value of y_2 is part of the
     values varied to achieve the optimum of J.
+--epsilon_parameters: The number of different epsilons used in the time integrations for
+    the optimization. The simulation time will be split into as many equally sized
+    intervals, such that there is an interval for each epsilon.
+--delta_t: The step size to be used for the time integrations.
+--epsilon_input_file: Optional file for the initial values of epsilon at the start of
+    the optimization. Must be formatted such that it can be read via np.loadtxt into an
+    array of size --num_parameters. If not provided, an array filled with 0.3 will be
+    used as default.
 """
 
 import argparse
@@ -40,6 +42,11 @@ from rkopenmdao.checkpoint_interface.pyrevolve_checkpointer import PyrevolveChec
 
 
 class VanDerPolComponent1(om.ImplicitComponent):
+    """
+    First component for the Van der Pol oscillator. Implements
+    y_1' = y_2.
+    """
+
     def initialize(self):
         self.options.declare("integration_control", types=IntegrationControl)
 
@@ -50,7 +57,7 @@ class VanDerPolComponent1(om.ImplicitComponent):
         self.add_output("y1_update", val=0.0, tags=["y1", "stage_output_var"])
         self.add_output("y1", val=2.0)
 
-    def apply_nonlinear(self, inputs, outputs, residuals):
+    def apply_nonlinear(self, inputs, outputs, residuals, *_args):
         delta_t = self.options["integration_control"].delta_t
         butcher_diagonal_element = self.options[
             "integration_control"
@@ -76,6 +83,7 @@ class VanDerPolComponent1(om.ImplicitComponent):
         )
 
     def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
+        # pylint: disable=too-many-branches
         delta_t = self.options["integration_control"].delta_t
         butcher_diagonal_element = self.options[
             "integration_control"
@@ -135,37 +143,43 @@ class VanDerPolComponent1(om.ImplicitComponent):
 
 
 class VanDerPolComponent2(om.ImplicitComponent):
+    """
+    First component for the Van der Pol oscillator. Implements
+    y_2' = ε * (1 - y_1**2)*y_2 - y_1.
+    """
+
+    _inv_jac: float
+
     def initialize(self):
         self.options.declare("integration_control", types=IntegrationControl)
-        self.options.declare("epsilon_mode", values=["one_for_all", "per_step"])
+        self.options.declare(
+            "num_parameters",
+            types=int,
+            default=1,
+            desc="""Defines how many epsilons are available over time. These will be
+                    placed equidistantly across time. There won't be any interpolation, 
+                    changes will be instantaneous.""",
+        )
+        self.options.declare("simulation_time", types=float)
 
     def setup(self):
-        if self.options["epsilon_mode"] == "one_for_all":
-            self.add_input(
-                "epsilon", val=1.0, tags=["epsilon", "time_independent_input_var"]
-            )
-        else:
-            self.add_input(
-                "epsilon",
-                val=np.ones(self.options["integration_control"].num_steps),
-                tags=["epsilon", "time_independent_input_var"],
-            )
+        self.add_input(
+            "epsilon",
+            val=np.ones(self.options["num_parameters"]),
+            tags=["epsilon", "time_independent_input_var"],
+        )
         self.add_input("y1", val=0.0)
         self.add_input("y2_old", val=-2.0 / 3.0, tags=["y2", "step_input_var"])
         self.add_input("y2s_i", val=0.0, tags=["y2", "accumulated_stage_var"])
         self.add_output("y2_update", val=0.0, tags=["y2", "stage_output_var"])
         self.add_output("y2", val=-2.0 / 3.0)
 
-    def apply_nonlinear(self, inputs, outputs, residuals):
+    def apply_nonlinear(self, inputs, outputs, residuals, *_args):
         delta_t = self.options["integration_control"].delta_t
         butcher_diagonal_element = self.options[
             "integration_control"
         ].butcher_diagonal_element
-        epsilon = (
-            inputs["epsilon"]
-            if self.options["epsilon_mode"] == "one_for_all"
-            else inputs["epsilon"][self.options["integration_control"].step - 1]
-        )
+        epsilon = inputs["epsilon"][self._get_epsilon_index()]
         residuals["y2_update"] = (
             outputs["y2_update"]
             - epsilon * (1 - inputs["y1"] ** 2) * outputs["y2"]
@@ -178,16 +192,12 @@ class VanDerPolComponent2(om.ImplicitComponent):
             - delta_t * butcher_diagonal_element * outputs["y2_update"]
         )
 
-    def solve_nonlinear(self, inputs, outputs):
+    def solve_nonlinear(self, inputs, outputs, *_args):
         delta_t = self.options["integration_control"].delta_t
         butcher_diagonal_element = self.options[
             "integration_control"
         ].butcher_diagonal_element
-        epsilon = (
-            inputs["epsilon"]
-            if self.options["epsilon_mode"] == "one_for_all"
-            else inputs["epsilon"][self.options["integration_control"].step - 1]
-        )
+        epsilon = inputs["epsilon"][self._get_epsilon_index()]
         divisor = (epsilon - inputs["y1"] ** 2) * delta_t * butcher_diagonal_element - 1
         outputs["y2_update"] = (
             inputs["y1"]
@@ -207,31 +217,24 @@ class VanDerPolComponent2(om.ImplicitComponent):
         butcher_diagonal_element = self.options[
             "integration_control"
         ].butcher_diagonal_element
-        epsilon = (
-            inputs["epsilon"]
-            if self.options["epsilon_mode"] == "one_for_all"
-            else inputs["epsilon"][self.options["integration_control"].step - 1]
-        )
+        epsilon = inputs["epsilon"][self._get_epsilon_index()]
         divisor = (
             1 - epsilon * (1 - inputs["y1"] ** 2) * delta_t * butcher_diagonal_element
         )
-        self.inv_jac = np.zeros((2, 2))
-        self.inv_jac[0, 0] = 1.0
-        self.inv_jac[0, 1] = epsilon * (1 - inputs["y1"][0] ** 2)
-        self.inv_jac[1, 0] = delta_t * butcher_diagonal_element
-        self.inv_jac[1, 1] = 1.0
-        self.inv_jac /= divisor
+        self._inv_jac = np.zeros((2, 2))
+        self._inv_jac[0, 0] = 1.0
+        self._inv_jac[0, 1] = epsilon * (1 - inputs["y1"][0] ** 2)
+        self._inv_jac[1, 0] = delta_t * butcher_diagonal_element
+        self._inv_jac[1, 1] = 1.0
+        self._inv_jac /= divisor
 
     def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
+        # pylint: disable=too-many-branches
         delta_t = self.options["integration_control"].delta_t
         butcher_diagonal_element = self.options[
             "integration_control"
         ].butcher_diagonal_element
-        epsilon = (
-            inputs["epsilon"]
-            if self.options["epsilon_mode"] == "one_for_all"
-            else inputs["epsilon"][self.options["integration_control"].step - 1]
-        )
+        epsilon = inputs["epsilon"][self._get_epsilon_index()]
         if mode == "fwd":
             if "y2_update" in d_residuals:
                 if "y2_update" in d_outputs:
@@ -248,13 +251,7 @@ class VanDerPolComponent2(om.ImplicitComponent):
                     d_residuals["y2_update"] -= (
                         (1 - inputs["y1"] ** 2)
                         * outputs["y2"]
-                        * (
-                            d_inputs["epsilon"]
-                            if self.options["epsilon_mode"] == "one_for_all"
-                            else d_inputs["epsilon"][
-                                self.options["integration_control"].step - 1
-                            ]
-                        )
+                        * (d_inputs["epsilon"][self._get_epsilon_index()])
                     )
             if "y2" in d_residuals:
                 if "y2" in d_outputs:
@@ -280,20 +277,11 @@ class VanDerPolComponent2(om.ImplicitComponent):
                         epsilon * (1 - inputs["y1"] ** 2) * d_residuals["y2_update"]
                     )
                 if "epsilon" in d_inputs:
-                    if self.options["epsilon_mode"] == "one_for_all":
-                        d_inputs["epsilon"] -= (
-                            (1 - inputs["y1"] ** 2)
-                            * outputs["y2"]
-                            * d_residuals["y2_update"]
-                        )
-                    else:
-                        d_inputs["epsilon"][
-                            self.options["integration_control"].step - 1
-                        ] -= (
-                            (1 - inputs["y1"] ** 2)
-                            * outputs["y2"]
-                            * d_residuals["y2_update"]
-                        )
+                    d_inputs["epsilon"][self._get_epsilon_index()] -= (
+                        (1 - inputs["y1"] ** 2)
+                        * outputs["y2"]
+                        * d_residuals["y2_update"]
+                    )
             if "y2" in d_residuals:
                 if "y2" in d_outputs:
                     d_outputs["y2"] += d_residuals["y2"]
@@ -309,37 +297,52 @@ class VanDerPolComponent2(om.ImplicitComponent):
     def solve_linear(self, d_outputs, d_residuals, mode):
         if mode == "fwd":
             d_outputs["y2_update"] = (
-                self.inv_jac[0, 0] * d_residuals["y2_update"]
-                + self.inv_jac[0, 1] * d_residuals["y2"]
+                self._inv_jac[0, 0] * d_residuals["y2_update"]
+                + self._inv_jac[0, 1] * d_residuals["y2"]
             )
             d_outputs["y2"] = (
-                self.inv_jac[1, 0] * d_residuals["y2_update"]
-                + self.inv_jac[1, 1] * d_residuals["y2"]
+                self._inv_jac[1, 0] * d_residuals["y2_update"]
+                + self._inv_jac[1, 1] * d_residuals["y2"]
             )
         elif mode == "rev":
             d_residuals["y2_update"] = (
-                self.inv_jac[0, 0] * d_outputs["y2_update"]
-                + self.inv_jac[1, 0] * d_outputs["y2"]
+                self._inv_jac[0, 0] * d_outputs["y2_update"]
+                + self._inv_jac[1, 0] * d_outputs["y2"]
             )
             d_residuals["y2"] = (
-                self.inv_jac[0, 1] * d_outputs["y2_update"]
-                + self.inv_jac[1, 1] * d_outputs["y2"]
+                self._inv_jac[0, 1] * d_outputs["y2_update"]
+                + self._inv_jac[1, 1] * d_outputs["y2"]
             )
+
+    def _get_epsilon_index(self):
+        time = self.options["integration_control"].stage_time
+        simulation_time = self.options[("simulation_time")]
+        num_params = self.options["num_parameters"]
+        for i in range(num_params - 1):
+            if time < simulation_time / num_params * (i + 1):
+                return i
+        return num_params - 1
 
 
 class VanDerPolFunctional(om.ExplicitComponent):
+    """
+    Functional to be used as example for the optimization with the Van der Pol
+    oscillator. Uses a continuous approximation of the absolute distance of a
+    curve to the unit circle (using |x| ≈ y* tanh(x))
+    """
+
     def setup(self):
         self.add_input("y1")
         self.add_input("y2")
         self.add_output("J", val=0.0, tags=["J", "stage_output_var"])
 
-    def compute(self, inputs, outputs, *args):
+    def compute(self, inputs, outputs, *_args):
 
         outputs["J"] = (inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1) * np.tanh(
             inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1
         )
 
-    def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode, *args):
+    def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode, *_args):
         tanh_value = np.tanh(inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1)
         tanh_deriv = tanh_value + (inputs["y1"] ** 2 + inputs["y2"] ** 2 - 1) * (
             1 - tanh_value**2
@@ -362,20 +365,26 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--y1_optimization", action="store_true")
     parser.add_argument("--y2_optimization", action="store_true")
-    parser.add_argument("--epsilon_mode", choices=["one_for_all", "per_step"])
+    parser.add_argument("--epsilon_parameters", type=int, default=1)
+    parser.add_argument("--delta_t", type=float, default=0.1)
+    parser.add_argument("--epsilon_input_file", type=str, default=None)
     parsed_args = parser.parse_args()
 
-    y1_optimization = parsed_args.y1_optimization
-    y2_optimization = parsed_args.y2_optimization
-    epsilon_mode = parsed_args.epsilon_mode
+    y1_optimization = bool(parsed_args.y1_optimization)
+    y2_optimization = bool(parsed_args.y2_optimization)
+    epsilon_parameters = parsed_args.epsilon_parameters
+    epsilon_input_file = parsed_args.epsilon_input_file
 
-    delta_t = 0.1
-    num_steps = 100
+    SIMULATION_TIME = 10.0
+    DELTA_T = parsed_args.delta_t
+    NUM_STEPS = int(SIMULATION_TIME / DELTA_T)
     butcher_tableau = third_order_four_stage_esdirk
-    integration_control = IntegrationControl(0.0, num_steps, delta_t)
+    integration_control = IntegrationControl(0.0, NUM_STEPS, DELTA_T)
     vdp_1 = VanDerPolComponent1(integration_control=integration_control)
     vdp_2 = VanDerPolComponent2(
-        integration_control=integration_control, epsilon_mode=epsilon_mode
+        integration_control=integration_control,
+        num_parameters=epsilon_parameters,
+        simulation_time=SIMULATION_TIME,
     )
     vdp_functional = VanDerPolFunctional()
 
@@ -385,14 +394,9 @@ if __name__ == "__main__":
     vdp_inner_prob.model.add_subsystem("vdp_functional", vdp_functional, promotes=["*"])
 
     vdp_inner_prob.model.nonlinear_solver = om.NewtonSolver(
-        solve_subsystems=False, iprint=2, err_on_non_converge=True, maxiter=1000
+        solve_subsystems=False, iprint=2, restart_from_successful=True, maxiter=1000
     )
     vdp_inner_prob.model.linear_solver = om.ScipyKrylov(iprint=2)
-
-    # vdp_inner_prob.setup()
-    # vdp_inner_prob.run_model()
-    # vdp_inner_prob.check_partials(show_only_incorrect=True)
-    # quit()
 
     vdp_rk_integrator = RungeKuttaIntegrator(
         time_stage_problem=vdp_inner_prob,
@@ -402,14 +406,15 @@ if __name__ == "__main__":
         time_independent_input_quantities=["epsilon"],
         checkpointing_type=PyrevolveCheckpointer,
         write_out_distance=1,
-        write_file="vdp.h5",
+        write_file=f"data/vdp_{DELTA_T}_{epsilon_parameters}_"
+        f"y1_{y1_optimization}_y2_{y2_optimization}.h5",
     )
 
     rk_prob = om.Problem()
     rk_prob.model.add_subsystem("rk_integration", vdp_rk_integrator, promotes=["*"])
     rk_prob.model.add_design_var("epsilon", lower=-10, upper=10)
     if y1_optimization:
-        rk_prob.model.add_objective("y1_initial", lower=-3, upper=3)
+        rk_prob.model.add_design_var("y1_initial", lower=-3, upper=3)
     if y2_optimization:
         rk_prob.model.add_design_var("y2_initial", lower=-3, upper=3)
     rk_prob.model.add_objective("J_final")
@@ -418,13 +423,25 @@ if __name__ == "__main__":
     rk_prob.setup()
     rk_prob["y1_initial"] = 2.0
     rk_prob["y2_initial"] = 2.0
-    rk_prob["epsilon"] = (
-        0.38  # optimization goes wrong for initial eps >= 0.4, works for eps <= 0.39
-    )
-    # rk_prob.run_model()
+
+    if epsilon_input_file is not None:
+        rk_prob["epsilon"] = np.loadtxt(epsilon_input_file)
+    else:
+        rk_prob["epsilon"].fill(0.3)
+        # optimization usually goes wrong for initial eps >= 0.4,
+        # and works for eps <= 0.39
 
     rk_prob.run_driver()
 
-    print(rk_prob["y2_initial"])
+    if y1_optimization:
+        print(rk_prob["y1_initial"])
+    if y2_optimization:
+        print(rk_prob["y2_initial"])
     print(rk_prob["epsilon"])
     print(rk_prob["J_final"])
+
+    np.savetxt(
+        f"data/vdp_epsilon_{DELTA_T}_{epsilon_parameters}"
+        f"_y1_{y1_optimization}_y2_{y2_optimization}.txt",
+        rk_prob["epsilon"],
+    )

--- a/examples/van_der_pol_oscillator/van_der_pol_oscillator_visualisation.py
+++ b/examples/van_der_pol_oscillator/van_der_pol_oscillator_visualisation.py
@@ -13,17 +13,31 @@ import numpy as np
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--num_of_files", type=int)
+parser.add_argument("--y1_optimization", action="store_true")
+parser.add_argument("--y2_optimization", action="store_true")
+parser.add_argument("--epsilon_parameters", type=int, default=1)
+parser.add_argument("--delta_t", type=float, default=0.1)
 
 parsed_args = parser.parse_args()
 num_of_files: int = parsed_args.num_of_files
+y1_optimization = bool(parsed_args.y1_optimization)
+y2_optimization = bool(parsed_args.y2_optimization)
+epsilon_parameters = parsed_args.epsilon_parameters
+delta_t = parsed_args.delta_t
 
 
 fig, ax = plt.subplots(1, 1)
-ax.set_xlim(-2.1, 2.1)
-ax.set_ylim(-2.1, 2.1)
-ims = []
-for files in range(num_of_files):
-    with h5py.File(f"vdp_{files}.h5", "r") as f:
+fig.suptitle("Van der Pol oscillator optimization")
+fig.subplots_adjust(top=0.8)
+
+
+def animation_frame(iternum: int):
+    """Function for a single from for FuncAnimation of matplotlib."""
+    with h5py.File(
+        f"data/vdp_{delta_t}_{epsilon_parameters}_y1_"
+        f"{y1_optimization}_y2_{y2_optimization}_{iternum}.h5",
+        "r",
+    ) as f:
         y1_arr = np.zeros(len(f["y1"]))
         y2_arr = np.zeros_like(y1_arr)
         times_arr = np.zeros_like(y1_arr)
@@ -32,10 +46,33 @@ for files in range(num_of_files):
         for i, val in f["y2"].items():
             y2_arr[int(i)] = val[0]
             times_arr[int(i)] = val.attrs["time"]
+        j = f["J"][str(y1_arr.size - 1)][:]
 
-    (im0,) = ax.plot(y1_arr, y2_arr, color="black")
-    (im1,) = ax.plot(y1_arr[0], y2_arr[0], color="black", marker="x")
-    ims.append([im0, im1])
+    ax.clear()
+    ax.set_xlim(-3.1, 3.1)
+    ax.set_ylim(-3.1, 3.1)
+    ax.set_xlabel("y_1")
+    ax.set_ylabel("y_2")
+    ax.plot(y1_arr, y2_arr, color="black")
+    ax.plot(y1_arr[0], y2_arr[0], color="black", marker="x")
+    ax.plot(
+        np.cos(np.linspace(0, 2 * np.pi, num=20)),
+        np.sin(np.linspace(0, 2 * np.pi, num=20)),
+        color="black",
+        linestyle="dashed",
+    )
+    ax.set_title(f"y_1 = {y1_arr[0]}, y_2 = {y2_arr[0]}\n J = {j}")
 
-ani = animation.ArtistAnimation(fig, ims, interval=250, blit=True, repeat=False)
-ani.save("vdp.gif")
+
+# ani = animation.ArtistAnimation(fig, ims, interval=500, blit=True, repeat=False)
+ani = animation.FuncAnimation(
+    fig,
+    animation_frame,
+    frames=num_of_files,
+    interval=500,
+    blit=False,
+    repeat_delay=2000,
+)
+ani.save(
+    f"vdp_{delta_t}_{epsilon_parameters}_y1_{y1_optimization}_y2_{y2_optimization}.gif"
+)

--- a/examples/van_der_pol_oscillator/van_der_pol_oscillator_visualisation.py
+++ b/examples/van_der_pol_oscillator/van_der_pol_oscillator_visualisation.py
@@ -1,0 +1,41 @@
+"""
+Plots the files created by the van_der_pol_oscillator_computation.py script.
+The argument --num_of_files should be set such that it is equal to the number of that
+script. This file then creates a gif showing the history of that optimization.
+"""
+
+import argparse
+
+import h5py
+import matplotlib.pyplot as plt
+from matplotlib import animation
+import numpy as np
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--num_of_files", type=int)
+
+parsed_args = parser.parse_args()
+num_of_files: int = parsed_args.num_of_files
+
+
+fig, ax = plt.subplots(1, 1)
+ax.set_xlim(-2.1, 2.1)
+ax.set_ylim(-2.1, 2.1)
+ims = []
+for files in range(num_of_files):
+    with h5py.File(f"vdp_{files}.h5", "r") as f:
+        y1_arr = np.zeros(len(f["y1"]))
+        y2_arr = np.zeros_like(y1_arr)
+        times_arr = np.zeros_like(y1_arr)
+        for i, val in f["y1"].items():
+            y1_arr[int(i)] = val[0]
+        for i, val in f["y2"].items():
+            y2_arr[int(i)] = val[0]
+            times_arr[int(i)] = val.attrs["time"]
+
+    (im0,) = ax.plot(y1_arr, y2_arr, color="black")
+    (im1,) = ax.plot(y1_arr[0], y2_arr[0], color="black", marker="x")
+    ims.append([im0, im1])
+
+ani = animation.ArtistAnimation(fig, ims, interval=250, blit=True, repeat=False)
+ani.save("vdp.gif")

--- a/src/rkopenmdao/__init__.py
+++ b/src/rkopenmdao/__init__.py
@@ -1,0 +1,3 @@
+from rich.traceback import install
+
+install(show_locals=True)

--- a/src/rkopenmdao/__init__.py
+++ b/src/rkopenmdao/__init__.py
@@ -1,3 +1,0 @@
-from rich.traceback import install
-
-install(show_locals=True)

--- a/src/rkopenmdao/runge_kutta_integrator.py
+++ b/src/rkopenmdao/runge_kutta_integrator.py
@@ -79,6 +79,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
 
     _disable_write_out: bool
     _file_writer: FileWriterInterface | None
+    _time_integration_number: int
 
     _checkpointer: CheckpointInterface | None
 
@@ -115,6 +116,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
 
         self._disable_write_out = False
         self._file_writer = None
+        self._time_integration_number = 0
 
         self._checkpointer = None
 
@@ -298,7 +300,6 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
         self._setup_arrays()
         self._setup_runge_kutta_scheme()
         self._setup_postprocessor()
-        self._configure_write_out()
         self._setup_checkpointing()
 
     def _setup_inner_problems(self):
@@ -538,8 +539,22 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
     def _configure_write_out(self):
         self._disable_write_out = self.options["write_out_distance"] == 0
         if not self._disable_write_out:
+            delimiter = self.options["write_file"].rfind(".")
+            if delimiter != -1:
+                file_name = (
+                    self.options["write_file"][:delimiter]
+                    + "_"
+                    + str(self._time_integration_number)
+                    + self.options["write_file"][delimiter:]
+                )
+            else:
+                file_name = (
+                    self.options["write_file"]
+                    + "_"
+                    + str(self._time_integration_number)
+                )
             self._file_writer = self.options["file_writing_implementation"](
-                self.options["write_file"], self._time_integration_metadata, self.comm
+                file_name, self._time_integration_metadata, self.comm
             )
 
     def _setup_checkpointing(self):
@@ -554,6 +569,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         if self.comm.rank == 0:
             print("\n\nStarting compute\n\n")
+        self._configure_write_out()
         self._compute_preparation_phase(inputs)
         self._compute_postprocessing_phase()
         self._compute_initial_write_out_phase()
@@ -561,6 +577,7 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
         self._compute_checkpointing_setup_phase()
         self._checkpointer.iterate_forward(self._serialized_state)
         self._compute_translate_to_om_vector_phase(outputs)
+        self._time_integration_number += 1
         if self.comm.rank == 0:
             print("\n\nFinishing compute\n\n")
 
@@ -1061,7 +1078,6 @@ class RungeKuttaIntegrator(om.ExplicitComponent):
         self._from_numpy_array_independent_input(
             self._independent_input_perturbations, d_inputs
         )
-        self._configure_write_out()
 
         # using the checkpoints invalidates the checkpointer in general
         self._cached_input = (np.full(0, np.nan), np.full(0, np.nan))

--- a/tests/write_file_test.py
+++ b/tests/write_file_test.py
@@ -16,8 +16,10 @@ from .test_postprocessing_problems import SquaringComponent
 
 @pytest.mark.rk
 @pytest.mark.parametrize("write_out_distance", [1, 10, 20, 30])
-@pytest.mark.parametrize("write_file", ["file.h5", "other_file.h5"])
-def test_monodisciplinary(write_out_distance, write_file):
+@pytest.mark.parametrize(
+    "write_file, expected_name", [("file.h5", "file_0.h5"), ("file", "file_0")]
+)
+def test_monodisciplinary(write_out_distance, write_file, expected_name):
     """Tests write-out for monodisciplinary problems."""
     test_prob = om.Problem()
     integration_control = IntegrationControl(1.0, 100, 0.01)
@@ -44,7 +46,7 @@ def test_monodisciplinary(write_out_distance, write_file):
     time_int_prob.setup()
     time_int_prob.run_model()
 
-    with h5py.File(write_file) as f:
+    with h5py.File(expected_name) as f:
         assert "x" in f.keys()
         for i in range(0, 100, write_out_distance):
             assert str(i) in f["x"].keys()
@@ -56,8 +58,10 @@ def test_monodisciplinary(write_out_distance, write_file):
 
 @pytest.mark.rk
 @pytest.mark.parametrize("write_out_distance", [1, 10, 20, 30])
-@pytest.mark.parametrize("write_file", ["file.h5", "other_file.h5"])
-def test_time_attribute(write_out_distance, write_file):
+@pytest.mark.parametrize(
+    "write_file, expected_name", [("file.h5", "file_0.h5"), ("file", "file_0")]
+)
+def test_time_attribute(write_out_distance, write_file, expected_name):
     """Checks that the time attribute in the written out file is correct."""
     test_prob = om.Problem()
     integration_control = IntegrationControl(1.0, 100, 0.01)
@@ -84,7 +88,7 @@ def test_time_attribute(write_out_distance, write_file):
     time_int_prob.setup()
     time_int_prob.run_model()
 
-    with h5py.File(write_file) as f:
+    with h5py.File(expected_name) as f:
         for i in range(0, 100, write_out_distance):
             assert f["x"][str(i)].attrs["time"] == pytest.approx(i * 0.01 + 1.0)
         assert f["x"][str(100)].attrs["time"] == pytest.approx(2.0)
@@ -92,8 +96,10 @@ def test_time_attribute(write_out_distance, write_file):
 
 @pytest.mark.rk
 @pytest.mark.parametrize("write_out_distance", [1, 10, 20, 30])
-@pytest.mark.parametrize("write_file", ["file.h5", "other_file.h5"])
-def test_multidisciplinary(write_out_distance, write_file):
+@pytest.mark.parametrize(
+    "write_file, expected_name", [("file.h5", "file_0.h5"), ("file", "file_0")]
+)
+def test_multidisciplinary(write_out_distance, write_file, expected_name):
     """Tests write-out for multidisciplinary problems."""
     test_prob = om.Problem()
     integration_control = IntegrationControl(1.0, 100, 0.01)
@@ -127,7 +133,7 @@ def test_multidisciplinary(write_out_distance, write_file):
     time_int_prob.setup()
     time_int_prob.run_model()
 
-    with h5py.File(write_file) as f:
+    with h5py.File(expected_name) as f:
         assert "x" in f.keys()
         assert "y" in f.keys()
         for i in range(0, 100, write_out_distance):
@@ -144,8 +150,10 @@ def test_multidisciplinary(write_out_distance, write_file):
 
 @pytest.mark.rk
 @pytest.mark.parametrize("write_out_distance", [1, 10, 20, 30])
-@pytest.mark.parametrize("write_file", ["file.h5", "other_file.h5"])
-def test_postprocessing(write_out_distance, write_file):
+@pytest.mark.parametrize(
+    "write_file, expected_name", [("file.h5", "file_0.h5"), ("file", "file_0")]
+)
+def test_postprocessing(write_out_distance, write_file, expected_name):
     """Tests write out when postprocessing is involved."""
     test_prob = om.Problem()
     integration_control = IntegrationControl(1.0, 100, 0.01)
@@ -179,7 +187,7 @@ def test_postprocessing(write_out_distance, write_file):
     time_int_prob.setup()
     time_int_prob.run_model()
 
-    with h5py.File(write_file) as f:
+    with h5py.File(expected_name) as f:
         assert "x" in f.keys()
         assert "squared_x" in f.keys()
         for i in range(0, 100, write_out_distance):
@@ -233,7 +241,7 @@ def test_n_d_array(write_out_distance):
     time_int_prob["time_int_initial"] = np.zeros((2, 2))
     time_int_prob.run_model()
 
-    with h5py.File("file.h5") as f:
+    with h5py.File("file_0.h5") as f:
         assert "time_int" in f.keys()
         for i in range(0, 100, write_out_distance):
             assert str(i) in f["time_int"].keys()
@@ -291,7 +299,7 @@ def test_parallel_write_out(write_out_distance, shape):
     )
     time_int_prob.run_model()
 
-    with h5py.File("file.h5", mode="r") as f:
+    with h5py.File("file_0.h5", mode="r") as f:
         assert "time_int" in f.keys()
         for i in range(0, 100, write_out_distance):
             assert str(i) in f["time_int"].keys()


### PR DESCRIPTION
Adds an example for optimization/optimal control involving the [Van der Pol oscillator](https://en.wikipedia.org/wiki/Van_der_Pol_oscillator). In the example the parameter epsilon of the oscillator (and optionally the initial values of the time integration) are optimized such that the trajectory of oscillator is as close to the unit circle as possible.
Also introduces some small changes to the time integration. Previously, multiple runs of the time integration where not possible when using the file output to hdf5-files. However, this is useful to have when in e.g. optimization, you want to have information about the change of trajectory. The new behaviour is to add the number of time integration after the base name of the file, right before the filename extension if there is any.