### PR TITLE
Use newer setup-python version in CI-Pipeline.

### DIFF
--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,7 +28,8 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install cython<3.0.0  # required to build petsc4py
+        pip install --no-binary=h5py h5py
+        pip install cython  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,7 +28,7 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install cython@3.0.12  # required to build petsc4py
+        pip install cython==3.0.12  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,7 +28,8 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install cython==3.0.12  # required to build petsc4py
+        CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
+        # pip install cython==3.0.12  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,12 +28,11 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install cython<3  # required to build petsc4py
+        pip install cython < 3  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py
         CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
-        pip install
     - name: Lint with pylint
       continue-on-error: true
       run: |

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,7 +28,7 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install cython  # required to build petsc4py
+        pip install cython<3.0.0  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -21,7 +21,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.8"
         cache: "pip"

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,7 +28,7 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install cython < 3  # required to build petsc4py
+        pip install cython  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,12 +28,11 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
+        CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py h5py
         # pip install cython==3.0.12  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py
-        CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
         pip install ".[dev]"
     - name: Lint with pylint
       continue-on-error: true

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,7 +28,7 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install cython  # required to build petsc4py
+        pip install cython@3.0.12  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,12 +28,12 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py h5py
-        # pip install cython==3.0.12  # required to build petsc4py
+        pip install cython<3  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py
-        pip install ".[dev]"
+        CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
+        pip install
     - name: Lint with pylint
       continue-on-error: true
       run: |

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
         python-version: "3.9"
@@ -32,6 +32,7 @@ jobs:
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc
         pip install petsc4py
+        pip install openmdao==3.33
         CC="mpicc" HDF5_MPI="ON" pip install --no-binary=h5py ".[dev]"
     - name: Lint with pylint
       continue-on-error: true

--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -23,12 +23,11 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
         cache: "pip"
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install --no-binary=h5py h5py
         pip install cython  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc


### PR DESCRIPTION
The current `actions/setup-python@v3` is outdated, so I bumped the version. This however lead to strange errors with the installation of h5py with respect to cython, which failed despite using the same versions of the software as in the previous versions. These errors ceased however once I bumped the python version from 3.8 to 3.9. Seeing that Python 3.8 is out of support anyway, I think this is a good idea anyway.

All of that Fixes #21.