### PR TITLE
Bump python version in CI

### DIFF
--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -20,10 +20,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libhdf5-openmpi-dev
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
         cache: "pip"
         cache-dependency-path: setup.py
     - name: Install dependencies


### PR DESCRIPTION
The currently used Python version in the CI-Pipeline (3.9) is already [end-of-life](https://devguide.python.org/versions/). This bumps python to the oldest still supported version (3.10).