### PR TITLE
Limit setuptools version in CI

### DIFF
--- a/.github/workflows/rkopenmdao_tests.yaml
+++ b/.github/workflows/rkopenmdao_tests.yaml
@@ -28,7 +28,8 @@ jobs:
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        export PIP_CONSTRAINT=<(printf "setuptools<81\n")
+        echo 'setuptools<81' > constraints.txt
+        export PIP_CONSTRAINT=constraints.txt
         pip install cython  # required to build petsc4py
         export PETSC_CONFIGURE_OPTIONS="--download-fblaslapack=1"
         pip install petsc


### PR DESCRIPTION
Currently, petsc4py doesn't work with setuptools 81 (https://gitlab.com/petsc/petsc/-/issues/1855). This MR limits the setuptools version in the CI to go around that issue.